### PR TITLE
[RF-47] 사이드바 애니메이션 및 터치 상호작용 구현

### DIFF
--- a/ReFree/Source/Recipe/View/RecipeSidebarView.swift
+++ b/ReFree/Source/Recipe/View/RecipeSidebarView.swift
@@ -10,12 +10,12 @@ import SnapKit
 import Then
 
 final class RecipeSidebarView: UIView {
-    private let bowlStack = FoodKindView(kind: .bowl)
-    private let soupStack = FoodKindView(kind: .soup)
-    private let sideStack = FoodKindView(kind: .sideMenu)
-    private let dessertStack = FoodKindView(kind: .dessert)
+    let bowlStack = FoodKindView(kind: .bowl)
+    let soupStack = FoodKindView(kind: .soup)
+    let sideStack = FoodKindView(kind: .sideMenu)
+    let dessertStack = FoodKindView(kind: .dessert)
     private let line = UIView()
-    private let saveStack = FoodKindView(kind: .save)
+    let saveStack = FoodKindView(kind: .save)
     
     private lazy var buttonStack = UIStackView(
         arrangedSubviews: [
@@ -32,7 +32,7 @@ final class RecipeSidebarView: UIView {
         $0.axis = .vertical
     }
     
-    private let backButton = UIButton().then {
+    let backButton = UIButton().then {
         $0.tintColor = .white
         $0.backgroundColor = .refreeColor.recipeBack1
         $0.setImage(UIImage(systemName: "chevron.left"), for: .normal)

--- a/ReFree/Source/Recipe/View/RecipeSidebarView.swift
+++ b/ReFree/Source/Recipe/View/RecipeSidebarView.swift
@@ -8,6 +8,8 @@
 import UIKit
 import SnapKit
 import Then
+import RxGesture
+import RxSwift
 
 final class RecipeSidebarView: UIView {
     let bowlStack = FoodKindView(kind: .bowl)
@@ -39,9 +41,12 @@ final class RecipeSidebarView: UIView {
         $0.layer.cornerRadius = 15
     }
     
+    private var disposeBag = DisposeBag()
+    
     init() {
         super.init(frame: .zero)
         layout()
+        bind()
     }
     
     required init?(coder: NSCoder) {
@@ -77,6 +82,30 @@ final class RecipeSidebarView: UIView {
         buttonStack.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(8)
             $0.centerY.equalToSuperview().offset(-50)
+        }
+    }
+    
+    private func bind() {
+        [
+            bowlStack,
+            soupStack,
+            sideStack,
+            dessertStack,
+            saveStack
+        ].forEach { target in
+            target.rx.touchDownGesture()
+                .when(.began)
+                .bind { _ in
+                    target.backgroundColor = .refreeColor.background3
+                }
+                .disposed(by: disposeBag)
+            
+            target.rx.touchDownGesture()
+                .when(.ended)
+                .bind { _ in
+                    target.backgroundColor = .clear
+                }
+                .disposed(by: disposeBag)
         }
     }
 }

--- a/ReFree/Source/Recipe/ViewController/RecipeViewController.swift
+++ b/ReFree/Source/Recipe/ViewController/RecipeViewController.swift
@@ -120,14 +120,13 @@ final class RecipeViewController: UIViewController {
             .disposed(by: disposeBag)
         
         let swipe = sidebar.rx.swipeGesture(.left).when(.recognized)
-            .map { _ in return 0}
+            .map { _ in return Void() }
         let tap = sidebar.backButton.rx.tap
-            .map { _ in return 0}
+            .map { _ in return Void() }
         
         Observable.merge([swipe,tap])
         .subscribe { [weak self] _ in
             self?.closeSidebar()
-            print("닫기")
         }
         .disposed(by: disposeBag)
     }

--- a/ReFree/Source/Recipe/ViewController/RecipeViewController.swift
+++ b/ReFree/Source/Recipe/ViewController/RecipeViewController.swift
@@ -121,10 +121,13 @@ final class RecipeViewController: UIViewController {
         
         let swipe = sidebar.rx.swipeGesture(.left).when(.recognized)
             .map { _ in return Void() }
-        let tap = sidebar.backButton.rx.tap
+        let sidebarCloseButtonTap = sidebar.backButton.rx.tap
             .map { _ in return Void() }
-        
-        Observable.merge([swipe,tap])
+    
+        Observable.merge([
+            swipe,
+            sidebarCloseButtonTap,
+        ])
         .subscribe { [weak self] _ in
             self?.closeSidebar()
         }


### PR DESCRIPTION
## 설명
[RF-47]
- 화면 상단이 약간 떠 보이는건 NavigationController안에 있어서 그렇습니다.
  - 추후 탭바로 들어갈 예정입니다.
- 사이드바 애니메이션은 Snpakit과 UIView.animte()를 이용해 구현했습니다.
- 사이드바를 닫는 모션은 닫기 버튼 터치, 사이드바 왼쪽 스와이프로 가능합니다.
-사이드바 컴포넌트 터치 시작 및 종료 시점에 배경색이 변경됩니다.

## 이슈
[RF-60] 사이드바 토글 애니메이션
[RF-152] 사이드바 터치 상호작용

#### Screenshot(Option)
![Simulator Screen Recording - iPhone 14 Pro Max - 2023-07-13 at 02 56 49](https://github.com/Re-Freee/ReFree-iOS/assets/86254784/9df9f17e-9b90-484e-bcf8-b0d2376577a1)



[RF-47]: https://juhun-lee.atlassian.net/browse/RF-47?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RF-60]: https://juhun-lee.atlassian.net/browse/RF-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RF-152]: https://juhun-lee.atlassian.net/browse/RF-152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ