### PR TITLE
[RF-127] 회원가입 이미지뷰, container view

### DIFF
--- a/ReFree.xcodeproj/project.pbxproj
+++ b/ReFree.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2E7CC82B2A6128750072C1F0 /* SignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E7CC82A2A6128750072C1F0 /* SignUpViewController.swift */; };
 		6A06E6122A5D1279005938DE /* RecipeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A06E6112A5D1279005938DE /* RecipeViewController.swift */; };
 		6A06E6142A5D1379005938DE /* RecipeTabHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A06E6132A5D1378005938DE /* RecipeTabHeader.swift */; };
 		6A06E6162A5D15B2005938DE /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A06E6152A5D15B2005938DE /* Constant.swift */; };
@@ -43,6 +44,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2E7CC82A2A6128750072C1F0 /* SignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpViewController.swift; sourceTree = "<group>"; };
 		6A06E6112A5D1279005938DE /* RecipeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeViewController.swift; sourceTree = "<group>"; };
 		6A06E6132A5D1378005938DE /* RecipeTabHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeTabHeader.swift; sourceTree = "<group>"; };
 		6A06E6152A5D15B2005938DE /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
@@ -91,6 +93,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2E7CC8292A6128630072C1F0 /* SignUp */ = {
+			isa = PBXGroup;
+			children = (
+				2E7CC82A2A6128750072C1F0 /* SignUpViewController.swift */,
+			);
+			path = SignUp;
+			sourceTree = "<group>";
+		};
 		6A06E60E2A5D1237005938DE /* Recipe */ = {
 			isa = PBXGroup;
 			children = (
@@ -191,6 +201,7 @@
 		6A7234F52A507334004FCFB4 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				2E7CC8292A6128630072C1F0 /* SignUp */,
 				6A7234F62A50734A004FCFB4 /* Common */,
 				6A0D30412A56C88600A9F44A /* SignIn */,
 				6A06E60E2A5D1237005938DE /* Recipe */,
@@ -352,6 +363,7 @@
 				6ACEE6C62A5C92F70084C41A /* UIView+gradient.swift in Sources */,
 				6A4ED1E12A5D432900299B61 /* UIVIew+Shadow.swift in Sources */,
 				6AA335EE2A6106290037A2C1 /* DetailStackView.swift in Sources */,
+				2E7CC82B2A6128750072C1F0 /* SignUpViewController.swift in Sources */,
 				6AA335E92A606F510037A2C1 /* IngredientDetailView.swift in Sources */,
 				6A0D30472A56C8DD00A9F44A /* SignInViewModel.swift in Sources */,
 				6A4ED1E52A5D4B4600299B61 /* CarouselCell.swift in Sources */,

--- a/ReFree/Source/SignUp/SignUpViewController.swift
+++ b/ReFree/Source/SignUp/SignUpViewController.swift
@@ -1,0 +1,206 @@
+//
+//  SignUpViewController.swift
+//  ReFree
+//
+//  Created by hwijinjeong on 2023/07/14.
+//
+
+import UIKit
+import SnapKit
+
+class SignUpViewController: UIViewController {
+    let rocketImageView = {
+        let view = UIImageView()
+        view.image = UIImage(named: "Rocket")
+        view.contentMode = .scaleAspectFill
+        
+        return view
+    }()
+    
+    let signupContainerView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        
+        return view
+    }()
+    
+    let signUpLabel = {
+        let label = UILabel()
+        label.font = UIFont(name: "Pretendard", size: 30)
+        label.font = .systemFont(ofSize: 30, weight: .bold)
+        label.textColor = .black
+        label.text = "Sign Up"
+        label.textAlignment = .center
+        
+        return label
+    }()
+    
+    let emailView = {
+        let view = UIView()
+        view.backgroundColor = .clear
+        
+        return view
+    }()
+    
+    let emailTextField = {
+        let textField = UITextField()
+        textField.placeholder = "이메일"
+        textField.borderStyle = .roundedRect
+        textField.textColor = .black
+//        textField.returnKeyType = .done
+        
+        return textField
+    }()
+    
+    let emailLabel = {
+        let label = UILabel()
+        label.font = UIFont(name: "Pretendard", size: 12)
+        label.font = .systemFont(ofSize: 12)
+        label.textColor = UIColor(red:208.0/255.0, green:0.0/255.0, blue:0.0/255.0, alpha:1.0)
+        label.text = "이미 존재하는 계정입니다."
+        label.textAlignment = .center
+        
+        return label
+    }()
+    
+    let passwordView = {
+        let view = UIView()
+        view.backgroundColor = .clear
+        
+        return view
+    }()
+    
+    let passwordTextField = {
+        let textField = UITextField()
+        textField.placeholder = "비밀번호"
+        textField.borderStyle = .roundedRect
+        textField.textColor = .black
+//        textField.returnKeyType = .done
+        
+        return textField
+    }()
+    
+    let confirmPasswordView = {
+        let view = UIView()
+        view.backgroundColor = .clear
+        
+        return view
+    }()
+    
+    let confirmPasswordTextField = {
+        let textField = UITextField()
+        textField.placeholder = "비밀번호 확인"
+        textField.borderStyle = .roundedRect
+        textField.textColor = .black
+//        textField.returnKeyType = .done
+        
+        return textField
+    }()
+    
+    let confirmPasswordLabel = {
+        let label = UILabel()
+        label.font = UIFont(name: "Pretendard", size: 12)
+        label.font = .systemFont(ofSize: 12)
+        label.textColor = UIColor(red:208.0/255.0, green:0.0/255.0, blue:0.0/255.0, alpha:1.0)
+        label.text = "비밀번호가 일치하지 않습니다."
+        label.textAlignment = .center
+        
+        return label
+    }()
+    
+    let nicknameView = {
+        let view = UIView()
+        view.backgroundColor = .clear
+        
+        return view
+    }()
+    
+    let nicknameTextField = {
+        let textField = UITextField()
+        textField.placeholder = "닉네임"
+        textField.borderStyle = .roundedRect
+        textField.textColor = .black
+//        textField.returnKeyType = .done
+        
+        return textField
+    }()
+    
+    
+    
+    lazy var stackView: UIStackView = {
+            let stackView = UIStackView(arrangedSubviews: [emailView, passwordView, confirmPasswordView, nicknameView])
+            stackView.axis = .vertical // default
+            stackView.distribution = .fill // default
+            stackView.alignment = .fill // default
+            view.addSubview(stackView)
+
+            return stackView
+        }()
+    
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.gradientBackground(type: .mainConic)
+        config()
+    }
+    
+    private func config(){
+        layout()
+    }
+    
+    private func layout(){
+        view.addSubview(rocketImageView)
+        view.addSubview(signupContainerView)
+        view.addSubview(signUpLabel)
+        view.addSubview(emailTextField)
+        
+        emailView.addSubview(emailTextField)
+        emailView.addSubview(emailLabel)
+        passwordView.addSubview(passwordTextField)
+        confirmPasswordView.addSubview(confirmPasswordTextField)
+        confirmPasswordView.addSubview(confirmPasswordLabel)
+        nicknameView.addSubview(nicknameTextField)
+        
+        view.addSubview(stackView)
+        
+        rocketImageView.snp.makeConstraints{ make in
+            make.width.equalTo(170)
+            make.height.equalTo(164)
+            make.top.equalTo(self.view.safeAreaLayoutGuide.snp.top).offset(42)
+            make.centerX.equalToSuperview()
+        }
+        
+        signupContainerView.snp.makeConstraints { make in
+            make.top.equalTo(rocketImageView.snp.bottom).offset(7)
+            make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom).offset(-150)
+            make.leading.equalTo(self.view.safeAreaLayoutGuide.snp.leading).offset(35)
+            make.trailing.equalTo(self.view.safeAreaLayoutGuide.snp.trailing).offset(-35)
+        }
+        
+        signupContainerView.layer.cornerRadius = 26
+        
+        signupContainerView.layer.borderWidth = 5
+        signupContainerView.layer.borderColor = UIColor.clear.cgColor
+        signupContainerView.layer.masksToBounds = false
+        signupContainerView.layer.shadowColor = UIColor.gray.cgColor
+        signupContainerView.layer.shadowOffset = CGSize(width: 0, height: 4)
+        signupContainerView.layer.shadowOpacity = 1
+        signupContainerView.layer.shadowRadius = 4
+        
+        signUpLabel.snp.makeConstraints { make in
+            make.top.equalTo(signupContainerView.snp.top).offset(34)
+            make.leading.equalTo(signupContainerView.snp.leading).offset(31)
+        }
+        
+        stackView.snp.makeConstraints { make in
+            make.top.equalTo(signUpLabel.snp.bottom).offset(30)
+            
+        }
+        
+        
+    }
+    
+
+
+}
+

--- a/ReFree/Source/SignUp/SignUpViewController.swift
+++ b/ReFree/Source/SignUp/SignUpViewController.swift
@@ -17,7 +17,7 @@ class SignUpViewController: UIViewController {
         return view
     }()
     
-    let signupContainerView = {
+    let signUpContainerView = {
         let view = UIView()
         view.backgroundColor = .white
         
@@ -149,10 +149,13 @@ class SignUpViewController: UIViewController {
     }
     
     private func layout(){
-        view.addSubview(rocketImageView)
-        view.addSubview(signupContainerView)
-        view.addSubview(signUpLabel)
-        view.addSubview(emailTextField)
+        view.addSubviews([
+            rocketImageView,
+            signUpContainerView,
+            signUpLabel,
+            emailTextField,
+            stackView
+        ])
         
         emailView.addSubview(emailTextField)
         emailView.addSubview(emailLabel)
@@ -161,7 +164,6 @@ class SignUpViewController: UIViewController {
         confirmPasswordView.addSubview(confirmPasswordLabel)
         nicknameView.addSubview(nicknameTextField)
         
-        view.addSubview(stackView)
         
         rocketImageView.snp.makeConstraints{ make in
             make.width.equalTo(170)
@@ -170,26 +172,26 @@ class SignUpViewController: UIViewController {
             make.centerX.equalToSuperview()
         }
         
-        signupContainerView.snp.makeConstraints { make in
+        signUpContainerView.snp.makeConstraints { make in
             make.top.equalTo(rocketImageView.snp.bottom).offset(7)
             make.bottom.equalTo(self.view.safeAreaLayoutGuide.snp.bottom).offset(-150)
             make.leading.equalTo(self.view.safeAreaLayoutGuide.snp.leading).offset(35)
             make.trailing.equalTo(self.view.safeAreaLayoutGuide.snp.trailing).offset(-35)
         }
         
-        signupContainerView.layer.cornerRadius = 26
+        signUpContainerView.layer.cornerRadius = 26
         
-        signupContainerView.layer.borderWidth = 5
-        signupContainerView.layer.borderColor = UIColor.clear.cgColor
-        signupContainerView.layer.masksToBounds = false
-        signupContainerView.layer.shadowColor = UIColor.gray.cgColor
-        signupContainerView.layer.shadowOffset = CGSize(width: 0, height: 4)
-        signupContainerView.layer.shadowOpacity = 1
-        signupContainerView.layer.shadowRadius = 4
+        signUpContainerView.layer.borderWidth = 5
+        signUpContainerView.layer.borderColor = UIColor.clear.cgColor
+        signUpContainerView.layer.masksToBounds = false
+        signUpContainerView.layer.shadowColor = UIColor.gray.cgColor
+        signUpContainerView.layer.shadowOffset = CGSize(width: 0, height: 4)
+        signUpContainerView.layer.shadowOpacity = 1
+        signUpContainerView.layer.shadowRadius = 4
         
         signUpLabel.snp.makeConstraints { make in
-            make.top.equalTo(signupContainerView.snp.top).offset(34)
-            make.leading.equalTo(signupContainerView.snp.leading).offset(31)
+            make.top.equalTo(signUpContainerView.snp.top).offset(34)
+            make.leading.equalTo(signUpContainerView.snp.leading).offset(31)
         }
         
         stackView.snp.makeConstraints { make in


### PR DESCRIPTION
## 설명
[RF-127]
- 회원가입 화면 상단의 이미지뷰를 추가하였습니다
- 회원가입 화면의 textfield를 담을 container view를 만들었습니다.
- 회원가입 정보 textfield를 담을 stackview를 만들었습니다(constraint 설정 x)

## 이슈
[RF-155]

#### Screenshot(Option)
<img width="338" alt="스크린샷 2023-07-14 오후 4 13 08" src="https://github.com/Re-Freee/ReFree-iOS/assets/80039139/fa81b200-a66e-402d-a2d7-e8da46cf08e9">




[RF-127]: https://juhun-lee.atlassian.net/browse/RF-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RF-155]: https://juhun-lee.atlassian.net/browse/RF-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ