### PR TITLE
[RF-49] [RF-169] 좋아하는 레시피 View 및 화면간 이동 구현

### DIFF
--- a/ReFree.xcodeproj/project.pbxproj
+++ b/ReFree.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		6A4ED1E12A5D432900299B61 /* UIVIew+Shadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4ED1E02A5D432900299B61 /* UIVIew+Shadow.swift */; };
 		6A4ED1E52A5D4B4600299B61 /* CarouselCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4ED1E42A5D4B4600299B61 /* CarouselCell.swift */; };
 		6A4ED1E72A5D4E0D00299B61 /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4ED1E62A5D4E0D00299B61 /* Identifiable.swift */; };
+		6A63C1E32A66B3E000E69D06 /* SavedRecipeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A63C1E22A66B3E000E69D06 /* SavedRecipeViewController.swift */; };
 		6A894D0D2A5F310200B053A5 /* RFModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A894D0C2A5F310200B053A5 /* RFModalViewController.swift */; };
 		6A8B10D12A62EABC0076A1CF /* KeyChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A8B10D02A62EABC0076A1CF /* KeyChain.swift */; };
 		6A8C53FA2A6136D5001EC332 /* PRETENDARD-EXTRALIGHT.TTF in Resources */ = {isa = PBXBuildFile; fileRef = 6A8C53F62A6136D4001EC332 /* PRETENDARD-EXTRALIGHT.TTF */; };
@@ -72,6 +73,7 @@
 		6A4ED1E02A5D432900299B61 /* UIVIew+Shadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIVIew+Shadow.swift"; sourceTree = "<group>"; };
 		6A4ED1E42A5D4B4600299B61 /* CarouselCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselCell.swift; sourceTree = "<group>"; };
 		6A4ED1E62A5D4E0D00299B61 /* Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
+		6A63C1E22A66B3E000E69D06 /* SavedRecipeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedRecipeViewController.swift; sourceTree = "<group>"; };
 		6A894D0C2A5F310200B053A5 /* RFModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFModalViewController.swift; sourceTree = "<group>"; };
 		6A8B10D02A62EABC0076A1CF /* KeyChain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChain.swift; sourceTree = "<group>"; };
 		6A8B10D42A62EE5A0076A1CF /* Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Development.xcconfig; sourceTree = "<group>"; };
@@ -208,6 +210,30 @@
 			path = ReFree/Source/SignUp;
 			sourceTree = SOURCE_ROOT;
 		};
+		6A63C1DF2A66B36700E69D06 /* SavedRecipe */ = {
+			isa = PBXGroup;
+			children = (
+				6A63C1E02A66B3B000E69D06 /* ViewController */,
+				6A63C1E12A66B3B600E69D06 /* View */,
+			);
+			path = SavedRecipe;
+			sourceTree = "<group>";
+		};
+		6A63C1E02A66B3B000E69D06 /* ViewController */ = {
+			isa = PBXGroup;
+			children = (
+				6A63C1E22A66B3E000E69D06 /* SavedRecipeViewController.swift */,
+			);
+			path = ViewController;
+			sourceTree = "<group>";
+		};
+		6A63C1E12A66B3B600E69D06 /* View */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
 		6A7234F32A507303004FCFB4 /* App */ = {
 			isa = PBXGroup;
 			children = (
@@ -237,6 +263,7 @@
 				6A7234F62A50734A004FCFB4 /* Common */,
 				6A1C0EB62A613EBE00A7C1C1 /* SignUp */,
 				6A06E60E2A5D1237005938DE /* Recipe */,
+				6A63C1DF2A66B36700E69D06 /* SavedRecipe */,
 				6A0D303D2A56C80F00A9F44A /* Util */,
 			);
 			path = Source;
@@ -450,6 +477,7 @@
 				6AA335F02A61066D0037A2C1 /* LineView.swift in Sources */,
 				6A4ED1DD2A5D31A800299B61 /* BadgeButton.swift in Sources */,
 				02ADE93D2A6136AA0017B69D /* HomeTabHeader.swift in Sources */,
+				6A63C1E32A66B3E000E69D06 /* SavedRecipeViewController.swift in Sources */,
 				6A894D0D2A5F310200B053A5 /* RFModalViewController.swift in Sources */,
 				6A8B10D12A62EABC0076A1CF /* KeyChain.swift in Sources */,
 				6A06E6122A5D1279005938DE /* RecipeViewController.swift in Sources */,

--- a/ReFree.xcodeproj/project.pbxproj
+++ b/ReFree.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		6A4ED1E12A5D432900299B61 /* UIVIew+Shadow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4ED1E02A5D432900299B61 /* UIVIew+Shadow.swift */; };
 		6A4ED1E52A5D4B4600299B61 /* CarouselCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4ED1E42A5D4B4600299B61 /* CarouselCell.swift */; };
 		6A4ED1E72A5D4E0D00299B61 /* Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A4ED1E62A5D4E0D00299B61 /* Identifiable.swift */; };
+		6A63A0782A66CAC1008EA0DC /* RecipeListCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A63A0772A66CAC1008EA0DC /* RecipeListCell.swift */; };
 		6A63C1E32A66B3E000E69D06 /* SavedRecipeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A63C1E22A66B3E000E69D06 /* SavedRecipeViewController.swift */; };
 		6A894D0D2A5F310200B053A5 /* RFModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A894D0C2A5F310200B053A5 /* RFModalViewController.swift */; };
 		6A8B10D12A62EABC0076A1CF /* KeyChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A8B10D02A62EABC0076A1CF /* KeyChain.swift */; };
@@ -73,6 +74,7 @@
 		6A4ED1E02A5D432900299B61 /* UIVIew+Shadow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIVIew+Shadow.swift"; sourceTree = "<group>"; };
 		6A4ED1E42A5D4B4600299B61 /* CarouselCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarouselCell.swift; sourceTree = "<group>"; };
 		6A4ED1E62A5D4E0D00299B61 /* Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Identifiable.swift; sourceTree = "<group>"; };
+		6A63A0772A66CAC1008EA0DC /* RecipeListCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeListCell.swift; sourceTree = "<group>"; };
 		6A63C1E22A66B3E000E69D06 /* SavedRecipeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedRecipeViewController.swift; sourceTree = "<group>"; };
 		6A894D0C2A5F310200B053A5 /* RFModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RFModalViewController.swift; sourceTree = "<group>"; };
 		6A8B10D02A62EABC0076A1CF /* KeyChain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChain.swift; sourceTree = "<group>"; };
@@ -230,6 +232,7 @@
 		6A63C1E12A66B3B600E69D06 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				6A63A0772A66CAC1008EA0DC /* RecipeListCell.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -457,6 +460,7 @@
 				6AA335EE2A6106290037A2C1 /* DetailStackView.swift in Sources */,
 				6AA335E92A606F510037A2C1 /* IngredientDetailView.swift in Sources */,
 				6A1C0EB82A613EBE00A7C1C1 /* SignUpViewController.swift in Sources */,
+				6A63A0782A66CAC1008EA0DC /* RecipeListCell.swift in Sources */,
 				6A9CDCE32A6557950003F618 /* NetworkTest.swift in Sources */,
 				6A4ED1E52A5D4B4600299B61 /* CarouselCell.swift in Sources */,
 				6AD7E3972A506C08007338DB /* AppDelegate.swift in Sources */,

--- a/ReFree/App/SceneDelegate.swift
+++ b/ReFree/App/SceneDelegate.swift
@@ -25,7 +25,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window.makeKeyAndVisible()
         
         self.window = window
-        Constant.screenSize = window.windowScene?.screen.bounds
+        if let height = window.windowScene?.screen.bounds {
+            Constant.screenSize = height
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/ReFree/Source/Common/View/RFModal/RecipeDetailView.swift
+++ b/ReFree/Source/Common/View/RFModal/RecipeDetailView.swift
@@ -13,8 +13,7 @@ final class RecipeDetailView: UIView {
     
     private enum CollectionSize {
         static var headerWidth: CGFloat {
-            guard let frameWidth = Constant.screenSize?.width else { return 0 }
-            return frameWidth - 48
+            return Constant.screenSize.width - 48
         }
         
         static var headerHeight: CGFloat {
@@ -22,10 +21,7 @@ final class RecipeDetailView: UIView {
         }
         
         static var defaultItemSize: CGSize {
-            guard
-                let width = Constant.screenSize?.width
-            else { return CGSize(width: 0, height: 0) }
-            return CGSize(width: width - 48, height: 100)
+            return CGSize(width: Constant.screenSize.width - 48, height: 100)
         }
     }
     

--- a/ReFree/Source/Common/View/RFSearchBar.swift
+++ b/ReFree/Source/Common/View/RFSearchBar.swift
@@ -23,13 +23,9 @@ final class RFSearchBar: UIView {
         image: UIImage(named: "Search")
     )
     
-    init(height: CGFloat = .zero) {
+    init(height: CGFloat = 40) {
         super.init(frame: .zero)
-        if height == .zero {
-            layout(height: 50)
-        } else {
-            layout(height: height)
-        }
+        layout(height: height)
     }
     
     override func layoutSubviews() {

--- a/ReFree/Source/Home/View/HomeTabHeader.swift
+++ b/ReFree/Source/Home/View/HomeTabHeader.swift
@@ -10,7 +10,7 @@ import SnapKit
 import Then
 
 class HomeTabHeader: UIView {
-    private let searchBar = RFSearchBar(height: 40)
+    private let searchBar = RFSearchBar()
     
     private let imminentFoodButton = UIButton().then {
         $0.setTitle("소비기한 임박 음식", for: .normal)

--- a/ReFree/Source/Recipe/View/BadgeButton.swift
+++ b/ReFree/Source/Recipe/View/BadgeButton.swift
@@ -11,7 +11,9 @@ import Then
 
 final class BadgeButton: UIView {
     private let heartButton = UIButton().then {
-        $0.setImage(UIImage(named: "Heart"), for: .normal)
+        $0.isEnabled = false
+        $0.setTitleColor(.black, for: .disabled)
+        $0.setImage(UIImage(named: "Heart"), for: .disabled)
     }
     
     private let redBadge = UIView().then {

--- a/ReFree/Source/Recipe/View/RecipeTabHeader.swift
+++ b/ReFree/Source/Recipe/View/RecipeTabHeader.swift
@@ -13,8 +13,8 @@ final class RecipeTabHeader: UIView {
     let sideBarToggleButton = UIButton().then {
         $0.setImage(UIImage(named: "HambergerButton"), for: .normal)
     }
-    private let bookmarkButton = BadgeButton(frame: .zero)
-    private let searchBar = RFSearchBar(height: 40)
+    let bookmarkButton = BadgeButton(frame: .zero)
+    let searchBar = RFSearchBar()
     private let titleLabel = UILabel().then {
         $0.textColor = .refreeColor.main
         $0.font = .pretendard.bold20

--- a/ReFree/Source/Recipe/ViewController/RecipeViewController.swift
+++ b/ReFree/Source/Recipe/ViewController/RecipeViewController.swift
@@ -14,17 +14,15 @@ import RxGesture
 final class RecipeViewController: UIViewController {
     private enum Const {
         static let itemSize = {
-            guard
-                let width = Constant.screenSize?.width,
-                let height = Constant.screenSize?.height
-            else { return CGSize(width: 200, height: 300) }
+            let width = Constant.screenSize.width
+            let height = Constant.screenSize.height
+            
             return CGSize(width: width*3/5, height: height*3/7)
         }()
         static let itemSpacing = 30.0
         
         static var insetX: CGFloat {
-            guard let screenWidth = Constant.screenSize?.width else { return 0 }
-            return ( screenWidth - self.itemSize.width) / 2.0
+            return ( Constant.screenSize.width - self.itemSize.width) / 2.0
         }
         static var collectionViewContentInset: UIEdgeInsets {
             UIEdgeInsets(top: 0, left: Self.insetX, bottom: 0, right: Self.insetX)
@@ -45,7 +43,6 @@ final class RecipeViewController: UIViewController {
         $0.contentInsetAdjustmentBehavior = .never
         $0.contentInset = Const.collectionViewContentInset
         $0.decelerationRate = .fast
-        $0.translatesAutoresizingMaskIntoConstraints = false
         
         $0.register(
             CarouselCell.self,
@@ -80,20 +77,7 @@ final class RecipeViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        let ratio = 0.7
-        guard
-            let height = view.window?.windowScene?.screen.bounds.height
-        else { return }
-        let extractedExpr = RFModalViewController(
-            modalHeight: height * ratio,
-            type: .recipe
-        )
-        let halfModal = extractedExpr
-        present(halfModal, animated: true)
+        navigationController?.isNavigationBarHidden = true
     }
     
     private func config() {
@@ -156,6 +140,14 @@ final class RecipeViewController: UIViewController {
             self?.closeSidebar()
         }
         .disposed(by: disposeBag)
+        
+        header.bookmarkButton.rx.tapGesture()
+            .when(.recognized)
+            .bind { [weak self] _ in
+                let vc = SavedRecipeViewController()
+                self?.navigationController?.pushViewController(vc, animated: true)
+            }
+            .disposed(by: disposeBag)
     }
     
     private func openSidebar() {
@@ -248,5 +240,20 @@ extension RecipeViewController: UICollectionViewDataSource {
         cell.setData()
         
         return cell
+    }
+    
+    func collectionView(
+        _ collectionView: UICollectionView,
+        didSelectItemAt indexPath: IndexPath
+    ) {
+        let ratio = 0.7
+        let height = Constant.screenSize.height
+        
+        let extractedExpr = RFModalViewController(
+            modalHeight: height * ratio,
+            type: .recipe
+        )
+        let halfModal = extractedExpr
+        present(halfModal, animated: true)
     }
 }

--- a/ReFree/Source/Recipe/ViewController/RecipeViewController.swift
+++ b/ReFree/Source/Recipe/ViewController/RecipeViewController.swift
@@ -182,6 +182,36 @@ final class RecipeViewController: UIViewController {
     }
 }
 
+extension RecipeViewController: UICollectionViewDataSource {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        numberOfItemsInSection section: Int
+    ) -> Int {
+        3
+    }
+    
+    func collectionView(
+        _ collectionView: UICollectionView,
+        cellForItemAt indexPath: IndexPath
+    ) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: CarouselCell.identifier,
+            for: indexPath
+        ) as? CarouselCell else { return UICollectionViewCell() }
+        
+        if previousIndex == nil {
+            UIView.animate(withDuration: 1) {
+                cell.transform = CGAffineTransform(scaleX: 1.1, y: 1.1)
+            }
+            previousIndex = 0
+        }
+        
+        cell.setData()
+        
+        return cell
+    }
+}
+
 extension RecipeViewController: UICollectionViewDelegateFlowLayout {
     func scrollViewWillEndDragging(
         _ scrollView: UIScrollView,
@@ -218,36 +248,6 @@ extension RecipeViewController: UICollectionViewDelegateFlowLayout {
         self.previousIndex = index
         pageControl.currentPage = index
     }
-}
-
-extension RecipeViewController: UICollectionViewDataSource {
-    func collectionView(
-        _ collectionView: UICollectionView,
-        numberOfItemsInSection section: Int
-    ) -> Int {
-        3
-    }
-    
-    func collectionView(
-        _ collectionView: UICollectionView,
-        cellForItemAt indexPath: IndexPath
-    ) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(
-            withReuseIdentifier: CarouselCell.identifier,
-            for: indexPath
-        ) as? CarouselCell else { return UICollectionViewCell() }
-        
-        if previousIndex == nil {
-            UIView.animate(withDuration: 1) {
-                cell.transform = CGAffineTransform(scaleX: 1.1, y: 1.1)
-            }
-            previousIndex = 0
-        }
-        
-        cell.setData()
-        
-        return cell
-    }
     
     func collectionView(
         _ collectionView: UICollectionView,
@@ -264,3 +264,5 @@ extension RecipeViewController: UICollectionViewDataSource {
         present(halfModal, animated: true)
     }
 }
+
+

--- a/ReFree/Source/Recipe/ViewController/RecipeViewController.swift
+++ b/ReFree/Source/Recipe/ViewController/RecipeViewController.swift
@@ -82,9 +82,16 @@ final class RecipeViewController: UIViewController {
     
     private func config() {
         view.gradientBackground(type: .mainAxial)
-        layout()
+        configNavigation()
         configCollectionView()
+        layout()
         bind()
+    }
+    
+    private func configNavigation() {
+        let backButton = UIBarButtonItem(title: nil, style: .plain, target: self, action: nil)
+        backButton.tintColor = .refreeColor.main
+        navigationItem.backBarButtonItem = backButton
     }
     
     private func layout() {

--- a/ReFree/Source/SavedRecipe/View/RecipeListCell.swift
+++ b/ReFree/Source/SavedRecipe/View/RecipeListCell.swift
@@ -1,0 +1,65 @@
+//
+//  RecipeListCell.swift
+//  ReFree
+//
+//  Created by 이주훈 on 2023/07/18.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class RecipeListCell: UICollectionViewCell, Identifiable {
+    private let imageView = UIImageView(image: UIImage(named: "FourCircle")).then {
+        $0.layer.opacity = 0.8
+    }
+    private let titleLabel = UILabel().then {
+        $0.numberOfLines = 1
+        $0.text = "돼지고기 김치찌개"
+        $0.textColor = .refreeColor.text3
+        $0.font = .pretendard.bold15
+    }
+    private let heartImageView = UIImageView(
+        image: UIImage(systemName: "heart.fill")?
+            .withRenderingMode(.alwaysOriginal)
+            .withTintColor(.white)
+    )
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        gradientBackground(type: .halfBlackAxial)
+        layout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func layout() {
+        clipsToBounds = true
+        layer.cornerRadius = 10
+        
+        addSubviews([
+            imageView,
+            titleLabel,
+            heartImageView
+        ])
+        
+        imageView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(24)
+            $0.width.equalToSuperview().multipliedBy(0.6)
+            $0.bottom.equalToSuperview().inset(24)
+        }
+        
+        heartImageView.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(24)
+            $0.width.height.equalTo(titleLabel.snp.height)
+            $0.bottom.equalToSuperview().inset(24)
+            
+        }
+    }
+}

--- a/ReFree/Source/SavedRecipe/ViewController/SavedRecipeViewController.swift
+++ b/ReFree/Source/SavedRecipe/ViewController/SavedRecipeViewController.swift
@@ -39,8 +39,13 @@ final class SavedRecipeViewController: UIViewController {
     
     private func config() {
         view.gradientBackground(type: .mainAxial)
-        collectionView.dataSource = self
+        configCollectionView()
         layout()
+    }
+    
+    private func configCollectionView() {
+        collectionView.dataSource = self
+        collectionView.delegate = self
     }
     
     private func layout() {
@@ -107,4 +112,16 @@ extension SavedRecipeViewController: UICollectionViewDataSource {
     }
 }
 
-
+extension SavedRecipeViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let ratio = 0.7
+        let height = Constant.screenSize.height
+        
+        let extractedExpr = RFModalViewController(
+            modalHeight: height * ratio,
+            type: .recipe
+        )
+        let halfModal = extractedExpr
+        present(halfModal, animated: true)
+    }
+}

--- a/ReFree/Source/SavedRecipe/ViewController/SavedRecipeViewController.swift
+++ b/ReFree/Source/SavedRecipe/ViewController/SavedRecipeViewController.swift
@@ -1,0 +1,122 @@
+//
+//  SavedRecipeViewController.swift
+//  ReFree
+//
+//  Created by 이주훈 on 2023/07/18.
+//
+
+import UIKit
+import SnapKit
+import Then
+
+final class SavedRecipeViewController: UIViewController {
+    private let titleLabel = UILabel().then {
+        $0.textColor = .refreeColor.main
+        $0.text = "저장한 레시피"
+        $0.font = .pretendard.extraBold30
+    }
+    private let searchBar = RFSearchBar()
+    private lazy var collectionView = UICollectionView(
+        frame: .zero,
+        collectionViewLayout: collectionViewLayout()
+    ).then {
+        $0.backgroundColor = .clear
+        $0.register(
+            RecipeCell.self,
+            forCellWithReuseIdentifier: RecipeCell.identifier
+        )
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        config()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        navigationController?.isNavigationBarHidden = false
+    }
+    
+    private func config() {
+        view.gradientBackground(type: .mainAxial)
+        collectionView.dataSource = self
+        layout()
+    }
+    
+    private func layout() {
+        view.addSubviews([
+            titleLabel,
+            searchBar,
+            collectionView
+        ])
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(24)
+        }
+        
+        searchBar.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(12)
+            $0.leading.trailing.equalTo(view.safeAreaLayoutGuide).inset(24)
+        }
+        
+        collectionView.snp.makeConstraints {
+            $0.top.equalTo(searchBar.snp.bottom).offset(24)
+            $0.leading.trailing.equalToSuperview().inset(4)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide)
+        }
+    }
+    
+    private func collectionViewLayout() -> UICollectionViewCompositionalLayout {
+        return UICollectionViewCompositionalLayout { _, _ in
+            let item = NSCollectionLayoutItem(
+                layoutSize: .init(
+                    widthDimension: .absolute((Constant.screenSize.width-8)/2),
+                    heightDimension: .absolute((Constant.screenSize.width-8)/2)
+                )
+            )
+
+            item.contentInsets = NSDirectionalEdgeInsets(top: 8, leading: 8, bottom: 8, trailing: 8)
+            
+            let group = NSCollectionLayoutGroup.horizontal(
+                layoutSize: .init(
+                    widthDimension: .fractionalWidth(1),
+                    heightDimension: .estimated(100)
+                ),
+                subitems: [item]
+            )
+            
+            let section = NSCollectionLayoutSection(group: group)
+//            section.interGroupSpacing = 8
+            
+            return section
+        }
+    }
+}
+
+extension SavedRecipeViewController: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        30
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: RecipeCell.identifier,
+            for: indexPath) as? RecipeCell
+        else { return UICollectionViewCell() }
+        
+        return cell
+    }
+}
+
+final class RecipeCell: UICollectionViewCell, Identifiable {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .black
+        layer.cornerRadius = 10
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/ReFree/Source/SavedRecipe/ViewController/SavedRecipeViewController.swift
+++ b/ReFree/Source/SavedRecipe/ViewController/SavedRecipeViewController.swift
@@ -22,8 +22,8 @@ final class SavedRecipeViewController: UIViewController {
     ).then {
         $0.backgroundColor = .clear
         $0.register(
-            RecipeCell.self,
-            forCellWithReuseIdentifier: RecipeCell.identifier
+            RecipeListCell.self,
+            forCellWithReuseIdentifier: RecipeListCell.identifier
         )
     }
     
@@ -85,9 +85,7 @@ final class SavedRecipeViewController: UIViewController {
                 ),
                 subitems: [item]
             )
-            
             let section = NSCollectionLayoutSection(group: group)
-//            section.interGroupSpacing = 8
             
             return section
         }
@@ -101,22 +99,12 @@ extension SavedRecipeViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(
-            withReuseIdentifier: RecipeCell.identifier,
-            for: indexPath) as? RecipeCell
+            withReuseIdentifier: RecipeListCell.identifier,
+            for: indexPath) as? RecipeListCell
         else { return UICollectionViewCell() }
         
         return cell
     }
 }
 
-final class RecipeCell: UICollectionViewCell, Identifiable {
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        backgroundColor = .black
-        layer.cornerRadius = 10
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-}
+

--- a/ReFree/Source/Util/Constant.swift
+++ b/ReFree/Source/Util/Constant.swift
@@ -16,5 +16,5 @@ struct Constant {
     static let spacing50: Int = 50
     static let spacing60: Int = 60
     
-    static var screenSize: CGRect?
+    static var screenSize: CGRect = .zero
 }

--- a/ReFree/Source/Util/Extension/UIView+gradient.swift
+++ b/ReFree/Source/Util/Extension/UIView+gradient.swift
@@ -13,6 +13,7 @@ extension UIView {
         case mainAxial
         case reverseMainAxial
         case blackAxial
+        case halfBlackAxial
     }
     
     func gradientBackground(type: BackgroundType) {
@@ -21,6 +22,7 @@ extension UIView {
         case .mainAxial: mainAxialBackground()
         case .reverseMainAxial: reverseMainAxialBackground()
         case .blackAxial: blackAxialBackground()
+        case .halfBlackAxial: halfBlackAxialBackground()
         }
     }
     
@@ -94,6 +96,21 @@ extension UIView {
             startPoint: CGPoint(x: 0.0, y: 0.0),
             endPoint: CGPoint(x: 1, y: 1),
             locations: [0.7]
+        )
+    }
+    
+    private func halfBlackAxialBackground() {
+        let colors: [CGColor] = [
+            UIColor.clear.cgColor,
+            UIColor.black.cgColor,
+        ]
+        
+        setGradientLayer(
+            type: .axial,
+            colors: colors,
+            startPoint: CGPoint(x: 0.5, y: 0.0),
+            endPoint: CGPoint(x: 0.5, y: 1),
+            locations: [-0.8]
         )
     }
     


### PR DESCRIPTION
## 설명
[RF-49]
[RF-169]
- 좋아하는 레시피 화면을 추가했습니다.
  -  Cell의 배경을 위해서 그라데이션으로 변하는 반투명 검정 배경을 구현했습니다.
- 간단하게 화면간 이동을 구현했습니다. (데이터 바인딩 X 단순 화면 이동 O)
- 

#### Screenshot(Option)
![Simulator Screen Recording - iPhone 14 Pro Max - 2023-07-18 at 22 42 47](https://github.com/Re-Freee/ReFree-iOS/assets/86254784/4bc870f7-cfbb-4c3b-98ab-f2b1341fe870)


[RF-49]: https://juhun-lee.atlassian.net/browse/RF-49?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RF-169]: https://juhun-lee.atlassian.net/browse/RF-169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ