### PR TITLE
[RF-259] 네트워크 명세에 맞춰 API 수정 및 

### DIFF
--- a/ReFree.xcodeproj/project.pbxproj
+++ b/ReFree.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		6AA335EE2A6106290037A2C1 /* DetailStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA335ED2A6106290037A2C1 /* DetailStackView.swift */; };
 		6AA335F02A61066D0037A2C1 /* LineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA335EF2A61066D0037A2C1 /* LineView.swift */; };
 		6AA94EC62A825FF8001489CD /* NetworkImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA94EC52A825FF8001489CD /* NetworkImage.swift */; };
+		6AA94EC82A82B12A001489CD /* Date+String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA94EC72A82B12A001489CD /* Date+String.swift */; };
 		6AC48A8E2A73C902009F647B /* RecipeResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC48A8D2A73C902009F647B /* RecipeResponseDTO.swift */; };
 		6AC48A922A73CB5C009F647B /* NetworkRecipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC48A912A73CB5C009F647B /* NetworkRecipe.swift */; };
 		6AC48A942A73D07B009F647B /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC48A932A73D07B009F647B /* NetworkError.swift */; };
@@ -187,6 +188,7 @@
 		6AA335ED2A6106290037A2C1 /* DetailStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailStackView.swift; sourceTree = "<group>"; };
 		6AA335EF2A61066D0037A2C1 /* LineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineView.swift; sourceTree = "<group>"; };
 		6AA94EC52A825FF8001489CD /* NetworkImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkImage.swift; sourceTree = "<group>"; };
+		6AA94EC72A82B12A001489CD /* Date+String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+String.swift"; sourceTree = "<group>"; };
 		6AC48A8D2A73C902009F647B /* RecipeResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeResponseDTO.swift; sourceTree = "<group>"; };
 		6AC48A912A73CB5C009F647B /* NetworkRecipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRecipe.swift; sourceTree = "<group>"; };
 		6AC48A932A73D07B009F647B /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
@@ -378,6 +380,7 @@
 				6A1C0EB92A61427400A7C1C1 /* UIFont+Pretendard.swift */,
 				2E35BAEF2A6C100E00D3C74C /* UIView+UIScreen.swift */,
 				2EC5B8B82A73D37500B83C92 /* UIView+alignBtnTextBelow.swift */,
+				6AA94EC72A82B12A001489CD /* Date+String.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -755,6 +758,7 @@
 				02B526C72A66A3260046D46E /* LogInViewController.swift in Sources */,
 				2EC5B8B92A73D37500B83C92 /* UIView+alignBtnTextBelow.swift in Sources */,
 				2E35BAED2A6C0FB500D3C74C /* SignUpViewController.swift in Sources */,
+				6AA94EC82A82B12A001489CD /* Date+String.swift in Sources */,
 				6A0D30402A56C83500A9F44A /* UIView+addSubViews.swift in Sources */,
 				02B526C92A66D6280046D46E /* LogInTextField.swift in Sources */,
 				6A51C5132A7823B100FF5341 /* IngredientRepository.swift in Sources */,

--- a/ReFree.xcodeproj/project.pbxproj
+++ b/ReFree.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		6AA335EB2A6070AB0037A2C1 /* UIView+StackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA335EA2A6070AB0037A2C1 /* UIView+StackView.swift */; };
 		6AA335EE2A6106290037A2C1 /* DetailStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA335ED2A6106290037A2C1 /* DetailStackView.swift */; };
 		6AA335F02A61066D0037A2C1 /* LineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA335EF2A61066D0037A2C1 /* LineView.swift */; };
+		6AA94EC62A825FF8001489CD /* NetworkImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AA94EC52A825FF8001489CD /* NetworkImage.swift */; };
 		6AC48A8E2A73C902009F647B /* RecipeResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC48A8D2A73C902009F647B /* RecipeResponseDTO.swift */; };
 		6AC48A922A73CB5C009F647B /* NetworkRecipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC48A912A73CB5C009F647B /* NetworkRecipe.swift */; };
 		6AC48A942A73D07B009F647B /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AC48A932A73D07B009F647B /* NetworkError.swift */; };
@@ -185,6 +186,7 @@
 		6AA335EA2A6070AB0037A2C1 /* UIView+StackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+StackView.swift"; sourceTree = "<group>"; };
 		6AA335ED2A6106290037A2C1 /* DetailStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailStackView.swift; sourceTree = "<group>"; };
 		6AA335EF2A61066D0037A2C1 /* LineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineView.swift; sourceTree = "<group>"; };
+		6AA94EC52A825FF8001489CD /* NetworkImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkImage.swift; sourceTree = "<group>"; };
 		6AC48A8D2A73C902009F647B /* RecipeResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeResponseDTO.swift; sourceTree = "<group>"; };
 		6AC48A912A73CB5C009F647B /* NetworkRecipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkRecipe.swift; sourceTree = "<group>"; };
 		6AC48A932A73D07B009F647B /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
@@ -577,6 +579,7 @@
 				6A9CDCE22A6557950003F618 /* NetworkTest.swift */,
 				6A5F07222A7407BA00526B18 /* NetworkSign.swift */,
 				6A5F07282A740E9800526B18 /* NetworkIngredient.swift */,
+				6AA94EC52A825FF8001489CD /* NetworkImage.swift */,
 			);
 			path = DataSource;
 			sourceTree = "<group>";
@@ -784,6 +787,7 @@
 				6A2B70732A5BF056002F92EB /* UIColor+ReFreeColor.swift in Sources */,
 				6A06E6142A5D1379005938DE /* RecipeTabHeader.swift in Sources */,
 				6A4ED1DF2A5D402700299B61 /* UITextFiled+Attribute.swift in Sources */,
+				6AA94EC62A825FF8001489CD /* NetworkImage.swift in Sources */,
 				6A5E934F2A75143D006659E2 /* IngredientInfoView.swift in Sources */,
 				6ADBAD602A7542FF009821AE /* AlertView.swift in Sources */,
 				02B526CD2A6702130046D46E /* LogInStackViewBackground.swift in Sources */,

--- a/ReFree/Source/Common/ViewController/AppInitViewController.swift
+++ b/ReFree/Source/Common/ViewController/AppInitViewController.swift
@@ -97,7 +97,7 @@ final class AppInitViewController: UIViewController {
         
         buttonStack.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.top.equalTo(logoTitleLabel.snp.bottom).offset(40)
+            $0.top.equalTo(logoTitleLabel.snp.bottom).offset(50)
             $0.width.equalTo(250)
         }
     }

--- a/ReFree/Source/Data/DTO/CommonResponseDTO.swift
+++ b/ReFree/Source/Data/DTO/CommonResponseDTO.swift
@@ -8,10 +8,10 @@
 import Foundation
 
 struct CommonResponseDTO: Decodable {
-    let code: String
+    let code: Int
     let message: String
     
     func toDomain() -> CommonResponse {
-        return CommonResponse(code: self.code, message: self.message)
+        return CommonResponse(code: "\(self.code)", message: self.message)
     }
 }

--- a/ReFree/Source/Data/DTO/FindPasswordRequestDTO.swift
+++ b/ReFree/Source/Data/DTO/FindPasswordRequestDTO.swift
@@ -9,4 +9,5 @@ import Foundation
 
 struct FindPasswordRequestDTO: Encodable {
     let email: String
+    let certification: String
 }

--- a/ReFree/Source/Data/DTO/IngredientResponseDTO.swift
+++ b/ReFree/Source/Data/DTO/IngredientResponseDTO.swift
@@ -12,11 +12,10 @@ struct IngredientResponseDTO: Decodable {
     let code: Int
     let message: String
     let count: Int?
-    let data: [IngredientDTO]
+    let data: [IngredientDTO]?
     
     struct IngredientDTO: Decodable {
-        let userId: Int
-        let ingredientID: Int
+        let ingredientId: Int
         let savedMethod: Int
         let name: String
         let period: String
@@ -25,27 +24,37 @@ struct IngredientResponseDTO: Decodable {
         let imageURL: String
         
         enum CodingKeys: String, CodingKey {
-            case userId = "member_id"
-            case ingredientID = "ingredient_id"
-            case savedMethod = "options"
+            case ingredientId = "id"
             case name = "name"
             case period = "period"
             case count = "quantity"
             case memo = "content"
+            case savedMethod = "options"
             case imageURL = "image"
         }
     }
     
     func toDomain() -> [Ingredient] {
-        return data.map {
+        return data?.map {
+            var savedMethod: String = ""
+            switch $0.savedMethod {
+            case 0: savedMethod = "실온"
+            case 1: savedMethod = "냉장"
+            case 2: savedMethod = "냉동"
+            case 3: savedMethod = "기타"
+            default: savedMethod = "기타"
+            }
+            
             return Ingredient(
-                saveMethod: "냉장", // TODO: API명세 누락으로 추후 변경
+                ingredientId: "\($0.ingredientId)",
+                imageURL: $0.imageURL,
+                saveMethod: savedMethod,
                 title: $0.name,
-                category: "\($0.ingredientID)", // TODO: ingredientID가 카테고리인지 모름
+                category: "\($0.ingredientId)", // TODO: 카테고리인가?
                 expireDate: $0.period,
                 count: $0.count,
                 memo: $0.memo
             )
-        }
+        } as! [Ingredient]
     }
 }

--- a/ReFree/Source/Data/DTO/ModifyPasswordRequestDTO.swift
+++ b/ReFree/Source/Data/DTO/ModifyPasswordRequestDTO.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct ModifyPasswordRequestDTO: Encodable {
+    let email: String
     let password: String
     let checkPassword: String
 }

--- a/ReFree/Source/Data/DTO/RecipeResponseDTO.swift
+++ b/ReFree/Source/Data/DTO/RecipeResponseDTO.swift
@@ -16,8 +16,8 @@ struct RecipeResponseDTO: Decodable {
     struct RecipeDTO: Decodable {
         let id: Int
         let name: String
-        let calorie: Double
-        let ingredient: String
+        let calorie: Double?
+        let ingredient: String?
         let imageURL: String
         let manual: [ManualDTO]?
         
@@ -56,7 +56,7 @@ extension RecipeResponseDTO {
             Recipe(
                 id: "\(recipeDTO.id)",
                 title: recipeDTO.name,
-                ingredients: recipeDTO.ingredient,
+                ingredients: recipeDTO.ingredient ?? "",
                 imageURL: recipeDTO.imageURL,
                 isHeart: false,
                 manual: recipeDTO.manual?.map{

--- a/ReFree/Source/Data/Domain/Ingredient.swift
+++ b/ReFree/Source/Data/Domain/Ingredient.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 struct Ingredient {
+    let ingredientId: String?
     let image: UIImage?
     let imageURL: String?
     let saveMethod: String?
@@ -18,6 +19,7 @@ struct Ingredient {
     let memo: String
     
     init(
+        ingredientId: String? = nil,
         image: UIImage? = UIImage(named: "ReFree_non"),
         imageURL: String? = nil,
         saveMethod: String? = nil,
@@ -27,6 +29,7 @@ struct Ingredient {
         count: Int? = nil,
         memo: String = ""
     ){
+        self.ingredientId = ingredientId
         self.image = image
         self.imageURL = imageURL
         self.saveMethod = saveMethod
@@ -37,6 +40,15 @@ struct Ingredient {
         self.memo = memo
     }
     
+    var option: Int? {
+        switch self.saveMethod {
+        case "실온": return 0
+        case "냉장": return 1
+        case "냉동": return 2
+        case "기타": return 3
+        default: return nil
+        }
+    }
     func setImage(image: UIImage?) -> Ingredient {
         return Ingredient(
             image: image,
@@ -165,3 +177,4 @@ struct Ingredient {
         return nil
     }
 }
+

--- a/ReFree/Source/Data/Domain/Ingredient.swift
+++ b/ReFree/Source/Data/Domain/Ingredient.swift
@@ -49,6 +49,7 @@ struct Ingredient {
         default: return nil
         }
     }
+    
     func setImage(image: UIImage?) -> Ingredient {
         return Ingredient(
             image: image,

--- a/ReFree/Source/Data/Repository/IngredientRepository.swift
+++ b/ReFree/Source/Data/Repository/IngredientRepository.swift
@@ -13,8 +13,8 @@ protocol IngredientRepositoryProtocol {
     func request(endIngredients: NetworkIngredient) -> Observable<[Ingredient]>
     func request(searchIngredients: NetworkIngredient) -> Observable<[Ingredient]>
     func request(detailIngredientt: NetworkIngredient) -> Observable<[Ingredient]>
-    func request(saveIngredient: NetworkIngredient) -> Observable<CommonResponse>
-    func request(modifyIngredient: NetworkIngredient) -> Observable<CommonResponse>
+    func request(saveIngredient: NetworkImage) -> Observable<CommonResponse>
+    func request(modifyIngredient: NetworkImage) -> Observable<CommonResponse>
 }
 
 struct IngredientRepository: IngredientRepositoryProtocol {
@@ -38,13 +38,13 @@ struct IngredientRepository: IngredientRepositoryProtocol {
         return observable.map { $0.toDomain() }
     }
     
-    func request(saveIngredient: NetworkIngredient) -> Observable<CommonResponse> {
-        let observable: Observable<CommonResponseDTO> = Network.requestJSON(target: saveIngredient)
+    func request(saveIngredient: NetworkImage) -> Observable<CommonResponse> {
+        let observable: Observable<CommonResponseDTO> = Network.imageUpload(target: saveIngredient)
         return observable.map { $0.toDomain() }
     }
     
-    func request(modifyIngredient: NetworkIngredient) -> Observable<CommonResponse> {
-        let observable: Observable<CommonResponseDTO> = Network.requestJSON(target: modifyIngredient)
+    func request(modifyIngredient: NetworkImage) -> Observable<CommonResponse> {
+        let observable: Observable<CommonResponseDTO> = Network.imageUpload(target: modifyIngredient)
         return observable.map { $0.toDomain() }
     }
 }

--- a/ReFree/Source/Data/Repository/SignRepository.swift
+++ b/ReFree/Source/Data/Repository/SignRepository.swift
@@ -10,21 +10,22 @@ import RxSwift
 
 
 protocol SignRepositoryProtocol {
-    func request(signIn: NetworkSign) -> Observable<CommonResponse> // TODO: 헤더 접근 수정 필요
-    func request(signUp: NetworkSign) -> Observable<CommonResponse>
+    func request(signIn: NetworkSign) -> Observable<(response: CommonResponse, token: String)>
+    func request(signUp: NetworkSign) -> Observable<(response: CommonResponse, backupCode: String)>
     func request(findPassword: NetworkSign) -> Observable<CommonResponse>
     func request(modifyPassword: NetworkSign) -> Observable<CommonResponse>
+    func request(withdrawUser: NetworkSign) -> Observable<CommonResponse>
 }
 
 struct SignRepository: SignRepositoryProtocol {
-    func request(signIn: NetworkSign) -> Observable<CommonResponse> {
-        let observable: Observable<CommonResponseDTO> = Network.requestJSON(target: signIn)
-        return observable.map { $0.toDomain() }
+    func request(signIn: NetworkSign) -> Observable<(response: CommonResponse, token: String)> {
+        let observable: Observable<(response: CommonResponseDTO, headerString: String)> = Network.requestJSONHeader(target: signIn)
+        return observable.map { ($0.response.toDomain(), $0.headerString) }
     }
     
-    func request(signUp: NetworkSign) -> Observable<CommonResponse> {
-        let observable: Observable<CommonResponseDTO> = Network.requestJSON(target: signUp)
-        return observable.map { $0.toDomain() }
+    func request(signUp: NetworkSign) -> Observable<(response: CommonResponse, backupCode: String)> {
+        let observable: Observable<(response: CommonResponseDTO, headerString: String)> = Network.requestJSONHeader(target: signUp)
+        return observable.map { ($0.response.toDomain(), $0.headerString) } 
     }
     
     func request(findPassword: NetworkSign) -> Observable<CommonResponse> {
@@ -34,6 +35,11 @@ struct SignRepository: SignRepositoryProtocol {
     
     func request(modifyPassword: NetworkSign) -> Observable<CommonResponse> {
         let observable: Observable<CommonResponseDTO> = Network.requestJSON(target: modifyPassword)
+        return observable.map { $0.toDomain() }
+    }
+    
+    func request(withdrawUser: NetworkSign) -> Observable<CommonResponse> {
+        let observable: Observable<CommonResponseDTO> = Network.requestJSON(target: withdrawUser)
         return observable.map { $0.toDomain() }
     }
 }

--- a/ReFree/Source/KindRecipe/View/RecipeListCell.swift
+++ b/ReFree/Source/KindRecipe/View/RecipeListCell.swift
@@ -59,7 +59,6 @@ final class RecipeListCell: UICollectionViewCell, Identifiable {
             $0.trailing.equalToSuperview().inset(24)
             $0.width.height.equalTo(titleLabel.snp.height)
             $0.bottom.equalToSuperview().inset(24)
-            
         }
     }
     

--- a/ReFree/Source/KindRecipe/ViewController/KindRecipeViewController.swift
+++ b/ReFree/Source/KindRecipe/ViewController/KindRecipeViewController.swift
@@ -175,13 +175,3 @@ extension KindRecipeViewController: UICollectionViewDelegateFlowLayout {
         )
     }
 }
-
-//extension KindRecipeViewController: UICollectionViewDataSourcePrefetching {
-//    func collectionView(
-//        _ collectionView: UICollectionView,
-//        prefetchItemsAt indexPaths: [IndexPath]
-//    ) {
-//        print("프리패치")
-//        print(indexPaths)
-//    }
-//}

--- a/ReFree/Source/LogIn/ViewController/LogInViewController.swift
+++ b/ReFree/Source/LogIn/ViewController/LogInViewController.swift
@@ -137,7 +137,6 @@ class LogInViewController: UIViewController {
                     Alert.erroAlert(viewController: self, errorMessage: response.message)
                     return
                 }
-                
                 do {
                     try KeyChain.shared.deleteToken(kind: .accessToken)
                     try KeyChain.shared.addToken(kind: .accessToken, token: token)

--- a/ReFree/Source/RegisterIngredient/View/IngredientInfoView.swift
+++ b/ReFree/Source/RegisterIngredient/View/IngredientInfoView.swift
@@ -365,4 +365,12 @@ final class IngredientInfoView: UIView {
         currentCountLabel.text = "\(newCount)"
         countSubject.onNext("\(newCount)")
     }
+    
+    func setDefault() {
+        selectIngredientKind.selectedSegmentIndex = 0
+        nameTextField.text = ""
+        expireDatePicker.date = Date()
+        currentCountLabel.text = "1"
+        memoTextView.text = ""
+    }
 }

--- a/ReFree/Source/RegisterIngredient/ViewController/RegisterIngredientViewController.swift
+++ b/ReFree/Source/RegisterIngredient/ViewController/RegisterIngredientViewController.swift
@@ -31,6 +31,7 @@ final class RegisterIngredientViewController: UIViewController {
     private let cameraView = CameraView()
     private let ingredientInfoView = IngredientInfoView()
     private var disposeBag = DisposeBag()
+    private let ingredientRepository = IngredientRepository()
     
     private var category: [String] = []
     
@@ -364,7 +365,32 @@ final class RegisterIngredientViewController: UIViewController {
     }
     
     private func registerIngredientHandling() {
-        //
+        ingredientRepository.request(saveIngredient: .saveIngredient(ingredient: info))
+            .subscribe(onNext: { [weak self] response in
+                guard let self else { return }
+                guard response.code == "200" else {
+                    Alert.erroAlert(viewController: self, errorMessage: response.message)
+                    return
+                }
+                Alert.checkAlert(
+                    viewController: self,
+                    title: "등록 완료!",
+                    message: "재료가 정상적으로 등록되었습니다!"
+                )
+                self.clearTextField()
+            }, onError: { error in
+                Alert.erroAlert(
+                    viewController: self,
+                    errorMessage: error.localizedDescription
+                )
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    private func clearTextField() {
+        cameraView.setDefault()
+        ingredientInfoView.setDefault()
+        info = Ingredient()
     }
     
     @objc private func keyboardUp(notification: NSNotification) {

--- a/ReFree/Source/RegisterIngredient/ViewController/RegisterIngredientViewController.swift
+++ b/ReFree/Source/RegisterIngredient/ViewController/RegisterIngredientViewController.swift
@@ -202,7 +202,7 @@ final class RegisterIngredientViewController: UIViewController {
             .map { $0 as Date }
             .subscribe(onNext: { [weak self] date in
                 guard let self else { return }
-                let dateString = date.description // TODO: formatting 필요
+                let dateString = date.toString()
                 self.info = self.info.setExpireDate(date: dateString)
             })
             .disposed(by: disposeBag)

--- a/ReFree/Source/SignUp/ViewController/AuthenticationCodeViewController.swift
+++ b/ReFree/Source/SignUp/ViewController/AuthenticationCodeViewController.swift
@@ -51,7 +51,7 @@ class AuthenticationCodeViewController: UIViewController {
     let codeLabel = UILabel().then {
         $0.font = .pretendard.extraBold30
         $0.textColor = UIColor.refreeColor.main
-        $0.text = "ABC123"
+        $0.text = ""
         $0.textAlignment = .center
     }
     
@@ -72,6 +72,8 @@ class AuthenticationCodeViewController: UIViewController {
         $0.tintColor = .white
     }
     
+    private var disposeBag = DisposeBag()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         view.gradientBackground(type: .mainConic)
@@ -80,6 +82,7 @@ class AuthenticationCodeViewController: UIViewController {
     
     private func config(){
         layout()
+        bind()
     }
 
     private func layout(){
@@ -160,9 +163,14 @@ class AuthenticationCodeViewController: UIViewController {
             $0.centerY.equalTo(continueButton.snp.centerY)
             $0.trailing.equalTo(continueButton.snp.trailing).offset(-10)
         }
-        
     }
     
-    
-    
+    private func bind() {
+        continueButton.rx.tap
+            .bind(onNext: { [weak self] _ in
+                let signUpCompleteVC = SignUpCompleteViewController()
+                self?.navigationController?.pushViewController(signUpCompleteVC, animated: true)
+            })
+            .disposed(by: disposeBag)
+    }
 }

--- a/ReFree/Source/SignUp/ViewController/SignUpViewController.swift
+++ b/ReFree/Source/SignUp/ViewController/SignUpViewController.swift
@@ -149,28 +149,28 @@ class SignUpViewController: UIViewController {
     }
     
     let emailValidityCheckButton = UIImageView().then {
-            $0.image = UIImage(named: "CircleCheck")
-            $0.contentMode = .scaleAspectFit
-            $0.isHidden = true
-        }
+        $0.image = UIImage(named: "CircleCheck")
+        $0.contentMode = .scaleAspectFit
+        $0.isHidden = true
+    }
     
     let passwordCheckButton = UIImageView().then {
-            $0.image = UIImage(named: "CircleCheck")
-            $0.contentMode = .scaleAspectFit
-            $0.isHidden = true
-        }
+        $0.image = UIImage(named: "CircleCheck")
+        $0.contentMode = .scaleAspectFit
+        $0.isHidden = true
+    }
     
     let confirmpPasswordCheckButton = UIImageView().then {
-            $0.image = UIImage(named: "CircleCheck")
-            $0.contentMode = .scaleAspectFit
-            $0.isHidden = true
-        }
+        $0.image = UIImage(named: "CircleCheck")
+        $0.contentMode = .scaleAspectFit
+        $0.isHidden = true
+    }
     
     let nicknameCheckButton = UIImageView().then {
-            $0.image = UIImage(named: "CircleCheck")
-            $0.contentMode = .scaleAspectFit
-            $0.isHidden = true
-        }
+        $0.image = UIImage(named: "CircleCheck")
+        $0.contentMode = .scaleAspectFit
+        $0.isHidden = true
+    }
     
     let passwordErrorButton = UIImageView().then {
         $0.image = UIImage(named: "CircleX")
@@ -201,6 +201,8 @@ class SignUpViewController: UIViewController {
     }
     
     private var disposeBag = DisposeBag()
+    private let signRepository = SignRepository()
+    
     
     private func isEmailValid(_ email: String) -> Bool {
         // 간단한 이메일 유효성 검사를 수행하는 함수
@@ -208,12 +210,12 @@ class SignUpViewController: UIViewController {
         let emailPredicate = NSPredicate(format:"SELF MATCHES %@", emailRegex)
         return emailPredicate.evaluate(with: email)
     }
-
+    
     private func isPasswordValid(_ password: String) -> Bool {
         // 비밀번호가 8자 이상인지 검사하는 함수
         return password.count >= 8
     }
-
+    
     private func isNicknameValid(_ nickname: String) -> Bool {
         // 닉네임이 2~8자인지 검사하는 함수
         return nickname.count >= 2 && nickname.count <= 8
@@ -227,23 +229,23 @@ class SignUpViewController: UIViewController {
             return false
         }
     }
-
+    
     
     @objc func TFdidChanged(_ sender: UITextField) {
         print("텍스트 변경 감지")
         if let text = sender.text {
             print("text :", text)
         }
-
+        
         // 이메일 유효성 검사
         if sender == emailTextField {
             emailValidityCheckButton.isHidden = !isEmailValid(sender.text ?? "")
         }
-
+        
         // 비밀번호 유효성 검사
         if sender == passwordTextField {
             passwordCheckButton.isHidden = isPasswordValid(sender.text ?? "")
-
+            
             // 비밀번호 길이 검사
             if passwordTextField.text?.count ?? 0 < 8 {
                 passwordCheckButton.isHidden = true
@@ -261,7 +263,7 @@ class SignUpViewController: UIViewController {
                 passwordCheckButton.isHidden = false // 비밀번호가 8자 이상인 경우에만 활성화
             }
         }
-
+        
         if sender == confirmPasswordTextField {
             if confirmPasswordTextField.text?.isEmpty ?? true {
                 confirmPasswordErrorButton.isHidden = true
@@ -281,7 +283,7 @@ class SignUpViewController: UIViewController {
                 }
             }
         }
-
+        
         // 닉네임 유효성 검사
         if sender == nicknameTextField {
             nicknameCheckButton.isHidden = isNicknameValid(sender.text ?? "")
@@ -296,20 +298,20 @@ class SignUpViewController: UIViewController {
                 nicknameLabel.isHidden = false
             }
         }
-
+        
         // 모든 조건을 만족할 경우에만 버튼 활성화
         updateNextButton()
     }
-
+    
     //'Create Account' 버튼 활성화/비활성화
     private func updateNextButton() {
-            // 각 필드의 유효성 검사 결과를 가져와서 버튼 활성화 여부 결정
+        // 각 필드의 유효성 검사 결과를 가져와서 버튼 활성화 여부 결정
         let isEmailFormatValid = isEmailValid(emailTextField.text ?? "")
         let isPasswordFormatValid = isPasswordValid(passwordTextField.text ?? "")
         let isPasswordsMatch = isSameBothTextField(passwordTextField, confirmPasswordTextField)
         let isNicknameFormatValid = isNicknameValid(nicknameTextField.text ?? "")
-            
-            // 모든 조건을 만족할 경우에만 버튼 활성화
+        
+        // 모든 조건을 만족할 경우에만 버튼 활성화
         createAccountButton.isEnabled = isEmailFormatValid && isPasswordFormatValid && isPasswordsMatch && isNicknameFormatValid
         createAccountButton.setTitleColor(createAccountButton.isEnabled ? UIColor.white : UIColor.gray, for: .normal)
     }
@@ -478,7 +480,7 @@ class SignUpViewController: UIViewController {
         
         createAccountButton.layer.cornerRadius = 13
         createAccountButton.layer.masksToBounds = true
- 
+        
         signUpLabel.snp.makeConstraints { make in
             make.top.equalTo(signUpContainerView.snp.top).offset(23)
             make.leading.equalTo(signUpContainerView.snp.leading).offset(31)
@@ -552,7 +554,7 @@ class SignUpViewController: UIViewController {
             $0.top.equalTo(nicknameTextField.snp.bottom).offset(4)
             $0.leading.equalTo(emailTextField.snp.leading).offset(9)
         }
-
+        
         
         stackView.snp.makeConstraints { make in
             make.top.equalTo(signUpLabel.snp.bottom).offset(23)
@@ -642,9 +644,44 @@ class SignUpViewController: UIViewController {
     }
     
     private func touchCreatAccountButton() {
-        // TODO: ValidCheck(유효성 검사) 후
-        let signUpCompleteVC = SignUpCompleteViewController()
-        navigationController?.pushViewController(signUpCompleteVC, animated: true)
+        guard
+            let email = emailTextField.text,
+            let password = passwordTextField.text,
+            let checkPassword = confirmPasswordTextField.text,
+            let nickName = nicknameTextField.text
+        else {
+            Alert.erroAlert(viewController: self, errorMessage: "채워주세요.")
+            return
+        }
+        
+        signRepository.request(
+            signUp: .signUp(
+                signUpData: SignUpData(
+                    email: email,
+                    password: password,
+                    checkPassword: checkPassword,
+                    nickName: nickName
+                )
+            )
+        )
+        .subscribe(onNext: { [weak self] (response, backupCode) in
+            guard let self else { return }
+            guard response.code == "201" else {
+                Alert.erroAlert(viewController: self, errorMessage: response.message)
+                return
+            }
+            
+            // TODO: 백업코드 보여주는 화면으로 이동 및 코드 할당
+            
+            let signUpCompleteVC = SignUpCompleteViewController()
+            self.navigationController?.pushViewController(signUpCompleteVC, animated: true)
+        }, onError: { error in
+            Alert.erroAlert(
+                viewController: self,
+                errorMessage: error.localizedDescription
+            )
+        })
+        .disposed(by: disposeBag)
     }
 }
 

--- a/ReFree/Source/SignUp/ViewController/SignUpViewController.swift
+++ b/ReFree/Source/SignUp/ViewController/SignUpViewController.swift
@@ -671,10 +671,9 @@ class SignUpViewController: UIViewController {
                 return
             }
             
-            // TODO: 백업코드 보여주는 화면으로 이동 및 코드 할당
-            
-            let signUpCompleteVC = SignUpCompleteViewController()
-            self.navigationController?.pushViewController(signUpCompleteVC, animated: true)
+            let AuthenticationCodeVC = AuthenticationCodeViewController()
+            AuthenticationCodeVC.codeLabel.text = backupCode
+            self.navigationController?.pushViewController(AuthenticationCodeVC, animated: true)
         }, onError: { error in
             Alert.erroAlert(
                 viewController: self,

--- a/ReFree/Source/Util/Extension/Date+String.swift
+++ b/ReFree/Source/Util/Extension/Date+String.swift
@@ -10,7 +10,7 @@ import Foundation
 extension Date {
     func toString() -> String {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy.mm.dd"
+        dateFormatter.dateFormat = "yyyy.MM.dd"
         return dateFormatter.string(from: self)
     }
 }

--- a/ReFree/Source/Util/Extension/Date+String.swift
+++ b/ReFree/Source/Util/Extension/Date+String.swift
@@ -1,0 +1,16 @@
+//
+//  Date+String.swift
+//  ReFree
+//
+//  Created by 이주훈 on 2023/08/09.
+//
+
+import Foundation
+
+extension Date {
+    func toString() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy.mm.dd"
+        return dateFormatter.string(from: self)
+    }
+}

--- a/ReFree/Source/Util/Network/DataSource/NetworkImage.swift
+++ b/ReFree/Source/Util/Network/DataSource/NetworkImage.swift
@@ -36,9 +36,8 @@ extension NetworkImage: ImageTarget {
         case .saveIngredient, .modifyIngredient:
             guard let token = try? KeyChain.shared.searchToken(kind: .accessToken)
             else { return [] }
-            
             return [
-                "Content-Type": "Multipart/form-data",
+                "Content-Type": "multipart/form-data",
                 "Authorization" : token
             ]
         }
@@ -68,7 +67,7 @@ extension NetworkImage: ImageTarget {
             return [
                 "name": title,
                  "category": category,
-                 "period" : period,
+                 "period" : "2023.08.13",
                  "quantity": quantity,
                  "content": ingredient.memo,
                  "options": options,

--- a/ReFree/Source/Util/Network/DataSource/NetworkImage.swift
+++ b/ReFree/Source/Util/Network/DataSource/NetworkImage.swift
@@ -67,7 +67,7 @@ extension NetworkImage: ImageTarget {
             return [
                 "name": title,
                  "category": category,
-                 "period" : "2023.08.13",
+                "period" : period,
                  "quantity": quantity,
                  "content": ingredient.memo,
                  "options": options,
@@ -87,7 +87,7 @@ extension NetworkImage: ImageTarget {
                 ImageData(
                     image: image,
                     withName: "image",
-                    fileName: "image"
+                    fileName: "image.jpg"
                 )
             ]
         }

--- a/ReFree/Source/Util/Network/DataSource/NetworkImage.swift
+++ b/ReFree/Source/Util/Network/DataSource/NetworkImage.swift
@@ -1,0 +1,96 @@
+//
+//  NetworkImage.swift
+//  ReFree
+//
+//  Created by 이주훈 on 2023/08/08.
+//
+
+import UIKit
+
+enum NetworkImage {
+    case saveIngredient(ingredient: Ingredient)
+    case modifyIngredient(ingredient: Ingredient)
+}
+
+extension NetworkImage: ImageTarget {
+    var baseURL: String {
+        return Network.server
+    }
+    
+    var url: URLConvertible {
+        switch self {
+        case .saveIngredient, .modifyIngredient:
+            return "\(baseURL)\(path)"
+        }
+    }
+    
+    var method: HTTPMethod {
+        switch self {
+        case .saveIngredient, .modifyIngredient:
+            return .post
+        }
+    }
+    
+    var header: HTTPHeaders {
+        switch self {
+        case .saveIngredient, .modifyIngredient:
+            guard let token = try? KeyChain.shared.searchToken(kind: .accessToken)
+            else { return [] }
+            
+            return [
+                "Content-Type": "Multipart/form-data",
+                "Authorization" : token
+            ]
+        }
+    }
+    
+    var path: String {
+        switch self {
+        case .saveIngredient:
+            return "/ingredient/create"
+        case .modifyIngredient(let ingredient):
+            guard let id = ingredient.ingredientId else {return ""}
+            return "/ingredient/edit/\(id)"
+        }
+    }
+    
+    var parameters: [String : Any]? {
+        switch self {
+        case .saveIngredient(let ingredient), .modifyIngredient(let ingredient):
+            guard
+                let title = ingredient.title,
+                let category = ingredient.category,
+                let period = ingredient.expireDate,
+                let quantity = ingredient.count,
+                let options = ingredient.option
+            else { return nil }
+                    
+            return [
+                "name": title,
+                 "category": category,
+                 "period" : period,
+                 "quantity": quantity,
+                 "content": ingredient.memo,
+                 "options": options,
+            ]
+        }
+    }
+    
+    var encoding: ParameterEncoding {
+        return JSONEncoding.default
+    }
+    
+    var imageData: [ImageData] {
+        switch self {
+        case .saveIngredient(let ingredient), .modifyIngredient(let ingredient):
+            guard let image = ingredient.image else { return [] }
+            return [
+                ImageData(
+                    image: image,
+                    withName: "image",
+                    fileName: "image"
+                )
+            ]
+        }
+    }
+}

--- a/ReFree/Source/Util/Network/DataSource/NetworkRecipe.swift
+++ b/ReFree/Source/Util/Network/DataSource/NetworkRecipe.swift
@@ -9,7 +9,7 @@ import Foundation
 
 enum NetworkRecipe {
     case recommendRecipe(ingredients: [String])
-    case searchRecipe(query: [RequestQuery]) // type=밥&title=샐러드
+    case searchRecipe(query: [RequestQuery]) // type=밥&title=샐러드,offset=0
     case bookMark(recipeID: String) // String은 레시피 ID
     case detailRecipe(recipeID: String) // String은 레시피 ID
     case savedRecipe
@@ -52,7 +52,13 @@ extension NetworkRecipe: Target {
     var header: HTTPHeaders {
         switch self {
         case .recommendRecipe, .searchRecipe, .bookMark, .detailRecipe, .savedRecipe:
-            return [ "Content-Type": "application/json" ] // TODO: Bearer Token 적용 필요   
+            guard let token = try? KeyChain.shared.searchToken(kind: .accessToken)
+            else { return [] }
+            
+            return [
+                "Content-Type": "application/json",
+                "Authorization" : token
+            ]
         }
     }
     

--- a/ReFree/Source/Util/Network/DataSource/NetworkSign.swift
+++ b/ReFree/Source/Util/Network/DataSource/NetworkSign.swift
@@ -10,8 +10,9 @@ import Foundation
 enum NetworkSign {
     case signIn(id: String, password: String)
     case signUp(signUpData: SignUpData)
-    case findPassword(email: String)
-    case modifyPassword(password: String, checkPassword: String)
+    case findPassword(email: String, certification: String)
+    case modifyPassword(email: String, password: String, checkPassword: String)
+    case withDraw
 }
 
 struct SignUpData {
@@ -34,6 +35,8 @@ extension NetworkSign: Target {
         switch self {
         case .signIn, .signUp, .findPassword, .modifyPassword:
             return .post
+        case .withDraw:
+            return .delete
         }
     }
     
@@ -51,6 +54,8 @@ extension NetworkSign: Target {
             return "/login/search"
         case .modifyPassword:
             return "/login/search/modify"
+        case .withDraw:
+            return "/member/delete"
         }
     }
     
@@ -66,15 +71,20 @@ extension NetworkSign: Target {
                 nickname: signUpData.nickName
             )
             return try? JSONEncoder().encode(signUpDTO)
-        case .findPassword(let email):
-            return try? JSONEncoder().encode(FindPasswordRequestDTO(email: email))
-        case .modifyPassword(let password, let checkPassword):
+        case .findPassword(let email, let certification):
+            return try? JSONEncoder().encode(
+                FindPasswordRequestDTO(email: email, certification: certification)
+            )
+        case .modifyPassword(let email,let password, let checkPassword):
             return try? JSONEncoder().encode(
                 ModifyPasswordRequestDTO(
+                    email: email,
                     password: password,
                     checkPassword: checkPassword
                 )
             )
+        case .withDraw:
+            return nil
         }
     }
     

--- a/ReFree/Source/Util/Network/Network.swift
+++ b/ReFree/Source/Util/Network/Network.swift
@@ -108,11 +108,13 @@ struct Network {
                         if
                             let str = value as? String,
                             let data = str.data(using: .utf8)
-                        { multipart.append(data , withName: key, mimeType: "text/plain") }
+                        {
+                            multipart.append(data , withName: key, mimeType: "text/plain") }
                         else if
                             let int = value as? Int,
                             let data = String(int).data(using: .utf8)
-                        { multipart.append(data , withName: key, mimeType: "text/plain") }
+                        {
+                            multipart.append(data , withName: key, mimeType: "text/plain") }
                     }
                     
                     target.imageData.forEach { data in
@@ -129,8 +131,6 @@ struct Network {
                             mimeType: data.mimeType
                         )
                     }
-                    
-//                    print(multipart["image"])
                 },
                 to: target.url,
                 method: target.method,

--- a/ReFree/Source/Util/Network/Network.swift
+++ b/ReFree/Source/Util/Network/Network.swift
@@ -125,12 +125,12 @@ struct Network {
                         multipart.append(
                             imageData,
                             withName: data.withName,
-                            fileName: "\(data.fileName).jpg",
+                            fileName: data.fileName,
                             mimeType: data.mimeType
                         )
                     }
                     
-                    print(multipart)
+//                    print(multipart["image"])
                 },
                 to: target.url,
                 method: target.method,

--- a/ReFree/Source/Util/Network/Network.swift
+++ b/ReFree/Source/Util/Network/Network.swift
@@ -108,27 +108,29 @@ struct Network {
                         if
                             let str = value as? String,
                             let data = str.data(using: .utf8)
-                        { multipart.append(data , withName: key) }
+                        { multipart.append(data , withName: key, mimeType: "text/plain") }
                         else if
                             let int = value as? Int,
                             let data = String(int).data(using: .utf8)
-                        { multipart.append(data , withName: key) }
+                        { multipart.append(data , withName: key, mimeType: "text/plain") }
                     }
                     
                     target.imageData.forEach { data in
                         guard
                             let imageData = data
-                            .image
-                            .jpegData(compressionQuality: 1)
+                                .image
+                                .jpegData(compressionQuality: 0.5)
                         else { return }
                         
                         multipart.append(
                             imageData,
                             withName: data.withName,
-                            fileName: data.fileName,
+                            fileName: "\(data.fileName).jpg",
                             mimeType: data.mimeType
                         )
                     }
+                    
+                    print(multipart)
                 },
                 to: target.url,
                 method: target.method,

--- a/ReFree/Source/Util/Network/NetworkError.swift
+++ b/ReFree/Source/Util/Network/NetworkError.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum NetworkError: Error {
     case makeRequestError
+    case tokenError
 }
 
 extension NetworkError: LocalizedError {
@@ -16,6 +17,8 @@ extension NetworkError: LocalizedError {
         switch self {
         case .makeRequestError:
             return NSLocalizedString("URLRequest 생성 실패", comment: "")
+        case .tokenError:
+            return NSLocalizedString("토큰이 정상적으로 발급되지 않았습니다.", comment: "")
         }
     }
 }

--- a/ReFree/Source/Util/Network/TargetProtocol.swift
+++ b/ReFree/Source/Util/Network/TargetProtocol.swift
@@ -49,7 +49,7 @@ struct ImageData {
     let image: UIImage
     let withName: String
     let fileName: String?
-    let mimeType: String = "image/jpeg"
+    let mimeType: String = "image/jpg"
 }
 
 extension Target {


### PR DESCRIPTION
## 설명
[RF-259]
- 네트워크 명세에 맞춰 전체적으로 수정했습니다. (눈알 빠질뻔)

[RF-260] 일부
- 회원가입, 로그인, 재료 등록을 연결했습니다.
- 백업코드를 받아 보여주는 뷰와 연결했습니다. (근데 코드가 길어서 잘림 -> 금요일 회의에서 코드 길이 or View 모양 수정)


[RF-259]: https://juhun-lee.atlassian.net/browse/RF-259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RF-260]: https://juhun-lee.atlassian.net/browse/RF-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ