### PR TITLE
[RF-283] response code와 message를 구분해 동작하도록 리팩토링

### DIFF
--- a/ReFree.xcodeproj/project.pbxproj
+++ b/ReFree.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		6AE16DC32A711595008D0C3C /* Ingredient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE16DC22A711595008D0C3C /* Ingredient.swift */; };
 		6AE16DC52A711642008D0C3C /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE16DC42A711642008D0C3C /* UserInfo.swift */; };
 		6AE5A99A2A865B7D005FBC47 /* UIView+ResponseCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE5A9992A865B7D005FBC47 /* UIView+ResponseCheck.swift */; };
+		6AE5A9A02A87BEA9005FBC47 /* UIViewController+ResponseCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AE5A99F2A87BEA9005FBC47 /* UIViewController+ResponseCheck.swift */; };
 		6AE80DBC2A507C21006CBB56 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 6AE80DBB2A507C21006CBB56 /* SnapKit */; };
 		6AE80DC22A507C89006CBB56 /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = 6AE80DC12A507C89006CBB56 /* Alamofire */; };
 		6AE80DCB2A507CDD006CBB56 /* RealmSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 6AE80DCA2A507CDD006CBB56 /* RealmSwift */; };
@@ -208,6 +209,7 @@
 		6AE16DC22A711595008D0C3C /* Ingredient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Ingredient.swift; sourceTree = "<group>"; };
 		6AE16DC42A711642008D0C3C /* UserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
 		6AE5A9992A865B7D005FBC47 /* UIView+ResponseCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+ResponseCheck.swift"; sourceTree = "<group>"; };
+		6AE5A99F2A87BEA9005FBC47 /* UIViewController+ResponseCheck.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+ResponseCheck.swift"; sourceTree = "<group>"; };
 		6AF713C22A76D68700F4CF96 /* CategorySelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySelectViewController.swift; sourceTree = "<group>"; };
 		6AF713C42A77745800F4CF96 /* CategoryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryTableViewCell.swift; sourceTree = "<group>"; };
 		6AF713C62A778BE000F4CF96 /* CategorySelectLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategorySelectLabel.swift; sourceTree = "<group>"; };
@@ -387,6 +389,7 @@
 				2EC5B8B82A73D37500B83C92 /* UIView+alignBtnTextBelow.swift */,
 				6AA94EC72A82B12A001489CD /* Date+String.swift */,
 				6AE5A9992A865B7D005FBC47 /* UIView+ResponseCheck.swift */,
+				6AE5A99F2A87BEA9005FBC47 /* UIViewController+ResponseCheck.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -824,6 +827,7 @@
 				6AD7E3992A506C08007338DB /* SceneDelegate.swift in Sources */,
 				02B526D52A6A5CAE0046D46E /* PasswordChangeViewController.swift in Sources */,
 				6A9D24FB2A5DC9AD0025BF3B /* RecipeSidebarView.swift in Sources */,
+				6AE5A9A02A87BEA9005FBC47 /* UIViewController+ResponseCheck.swift in Sources */,
 				6A5F071D2A73DF2A00526B18 /* FindPasswordRequestDTO.swift in Sources */,
 				6AA335F02A61066D0037A2C1 /* LineView.swift in Sources */,
 				6A5E934D2A751434006659E2 /* CameraView.swift in Sources */,

--- a/ReFree/App/SceneDelegate.swift
+++ b/ReFree/App/SceneDelegate.swift
@@ -10,6 +10,7 @@ import SnapKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
+    var globalNavigation: UINavigationController?
     
     func scene(
         _ scene: UIScene,
@@ -20,6 +21,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         let window = UIWindow(windowScene: windowScene)
         let navigation = UINavigationController(rootViewController: AppInitViewController())
+        globalNavigation = navigation
         if let _ = try? KeyChain.shared.searchToken(kind: .accessToken) {
             navigation.pushViewController(HomeTabViewController(), animated: false)
         }
@@ -72,6 +74,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Called as the scene transitions from the foreground to the background.
         // Use this method to save data, release shared resources, and store enough scene-specific state information
         // to restore the scene back to its current state.
+    }
+    
+    func popToRootViewController() {
+        guard let globalNavigation else { return }
+        globalNavigation.popToRootViewController(animated: true)
+        guard let initViewController = globalNavigation.topViewController else { return }
+        Alert.checkAlert(
+            viewController: initViewController,
+            title: "알림",
+            message: "로그인이 만료되었습니다.\n다시 로그인해 주세요."
+        )
     }
 }
 

--- a/ReFree/Source/Common/View/RFModal/IngredientDetailView.swift
+++ b/ReFree/Source/Common/View/RFModal/IngredientDetailView.swift
@@ -134,6 +134,7 @@ final class IngredientDetailView: UIView {
         guard let id = ingredient.ingredientId else { return }
         ingredientRepository.request(detailIngredient: .detailIngredient(ingredientId: id))
             .subscribe(onNext: { [weak self] (commonResponse, ingredients) in
+                self?.responseCheck(response: commonResponse)
                 guard
                     let self,
                     let ingredient = ingredients.first

--- a/ReFree/Source/Common/View/RFModal/IngredientDetailView.swift
+++ b/ReFree/Source/Common/View/RFModal/IngredientDetailView.swift
@@ -167,7 +167,6 @@ final class IngredientDetailView: UIView {
             .request(deleteIngredient: .deleteIngredient(ingredientId: id))
             .subscribe(onNext: { [weak self] response in
                 guard let self else { return }
-                self.checkResponse(response: response)
                 alertSubject.onNext("삭제가 완료되었습니다.")
             }, onError: { error in
                 self.errorSubject.onNext(error.localizedDescription)

--- a/ReFree/Source/Common/View/RFModal/IngredientDetailView.swift
+++ b/ReFree/Source/Common/View/RFModal/IngredientDetailView.swift
@@ -133,7 +133,7 @@ final class IngredientDetailView: UIView {
         
         guard let id = ingredient.ingredientId else { return }
         ingredientRepository.request(detailIngredient: .detailIngredient(ingredientId: id))
-            .subscribe(onNext: { [weak self] ingredients in
+            .subscribe(onNext: { [weak self] (commonResponse, ingredients) in
                 guard
                     let self,
                     let ingredient = ingredients.first

--- a/ReFree/Source/Common/View/RFModal/RecipeDetailView.swift
+++ b/ReFree/Source/Common/View/RFModal/RecipeDetailView.swift
@@ -108,7 +108,7 @@ final class RecipeDetailView: UIView {
         self.recipe = recipe
         recipeRepository
             .request(detailRecipe: .detailRecipe(recipeID: recipe.id))
-            .subscribe(onNext: { [weak self] manual in
+            .subscribe(onNext: { [weak self] (commonResponse, manual) in
                 guard let self else { return }
                 self.manual = manual
                 self.recipeCollection.reloadData()

--- a/ReFree/Source/Common/View/RFModal/RecipeDetailView.swift
+++ b/ReFree/Source/Common/View/RFModal/RecipeDetailView.swift
@@ -109,6 +109,7 @@ final class RecipeDetailView: UIView {
         recipeRepository
             .request(detailRecipe: .detailRecipe(recipeID: recipe.id))
             .subscribe(onNext: { [weak self] (commonResponse, manual) in
+                self?.responseCheck(response: commonResponse)
                 guard let self else { return }
                 self.manual = manual
                 self.recipeCollection.reloadData()

--- a/ReFree/Source/Data/DTO/IngredientResponseDTO.swift
+++ b/ReFree/Source/Data/DTO/IngredientResponseDTO.swift
@@ -37,28 +37,35 @@ struct IngredientResponseDTO: Decodable {
         }
     }
     
-    func toDomain() -> [Ingredient] {
-        return data?.map {
-            var savedMethod: String = ""
-            switch $0.savedMethod {
-            case 0: savedMethod = "실온"
-            case 1: savedMethod = "냉장"
-            case 2: savedMethod = "냉동"
-            case 3: savedMethod = "기타"
-            default: savedMethod = "기타"
+    func toDomain() -> (commonResponse: CommonResponse, ingredients: [Ingredient]) {
+        guard let data else {
+            return (CommonResponse(code: "\(code)", message: message), [])
+        }
+        
+        return (
+            CommonResponse(code: "\(code)", message: message),
+            data.map {
+                var savedMethod: String = ""
+                switch $0.savedMethod {
+                case 0: savedMethod = "실온"
+                case 1: savedMethod = "냉장"
+                case 2: savedMethod = "냉동"
+                case 3: savedMethod = "기타"
+                default: savedMethod = "기타"
+                }
+                
+                let extractedExpr = Ingredient(
+                    ingredientId: "\($0.ingredientId)",
+                    imageURL: $0.imageURL,
+                    saveMethod: savedMethod,
+                    title: $0.name,
+                    category: $0.category,
+                    expireDate: $0.period,
+                    count: $0.count,
+                    memo: $0.memo ?? ""
+                )
+                return extractedExpr
             }
-            
-            let extractedExpr = Ingredient(
-                ingredientId: "\($0.ingredientId)",
-                imageURL: $0.imageURL,
-                saveMethod: savedMethod,
-                title: $0.name,
-                category: $0.category,
-                expireDate: $0.period,
-                count: $0.count,
-                memo: $0.memo ?? ""
-            )
-            return extractedExpr
-        } as! [Ingredient]
+        )
     }
 }

--- a/ReFree/Source/Data/DTO/RecipeResponseDTO.swift
+++ b/ReFree/Source/Data/DTO/RecipeResponseDTO.swift
@@ -73,13 +73,19 @@ extension RecipeResponseDTO {
         )
     }
     
-    func toDomainManual() -> [Manual] {
-        guard let manualData = data?.first?.manual else { return [] }
-        return manualData.map{ manualDTO in
-            Manual(
-                describe: manualDTO.describe,
-                imageURL: manualDTO.manualImageURL
-            )
-        }
+    func toDomainManual() -> (commonResponse: CommonResponse, manuals: [Manual]) {
+        guard
+            let manualData = data?.first?.manual
+        else { return (CommonResponse(code: "\(code)", message: message), []) }
+        
+        return (
+            CommonResponse(code: "\(code)", message: message),
+            manualData.map{ manualDTO in
+               Manual(
+                   describe: manualDTO.describe,
+                   imageURL: manualDTO.manualImageURL
+               )
+           }
+        )
     }
 }

--- a/ReFree/Source/Data/DTO/RecipeResponseDTO.swift
+++ b/ReFree/Source/Data/DTO/RecipeResponseDTO.swift
@@ -52,20 +52,25 @@ struct RecipeResponseDTO: Decodable {
 }
 
 extension RecipeResponseDTO {
-    func toDomain() -> [Recipe] {
-        guard let data else { return [] }
-        return data.map { recipeDTO in
-            Recipe(
-                id: "\(recipeDTO.id)",
-                title: recipeDTO.name,
-                ingredients: recipeDTO.ingredient ?? "",
-                imageURL: recipeDTO.imageURL,
-                isHeart: recipeDTO.isHeart == 1 ? true : false,
-                manual: recipeDTO.manual?.map{
-                    $0.toDomain()
-                }
-            )
+    func toDomain() -> (commonResponse: CommonResponse, recipes: [Recipe]) {
+        guard let data else {
+            return (CommonResponse(code: "\(code)", message: message), [])
         }
+        return (
+            CommonResponse(code: "\(code)", message: message),
+            data.map { recipeDTO in
+                Recipe(
+                    id: "\(recipeDTO.id)",
+                    title: recipeDTO.name,
+                    ingredients: recipeDTO.ingredient ?? "",
+                    imageURL: recipeDTO.imageURL,
+                    isHeart: recipeDTO.isHeart == 1 ? true : false,
+                    manual: recipeDTO.manual?.map{
+                        $0.toDomain()
+                    }
+                )
+            }
+        )
     }
     
     func toDomainManual() -> [Manual] {

--- a/ReFree/Source/Data/Repository/IngredientRepository.swift
+++ b/ReFree/Source/Data/Repository/IngredientRepository.swift
@@ -9,32 +9,49 @@ import Foundation
 import RxSwift
 
 protocol IngredientRepositoryProtocol {
-    func request(closerIngredients: NetworkIngredient) -> Observable<[Ingredient]>
-    func request(endIngredients: NetworkIngredient) -> Observable<[Ingredient]>
-    func request(searchIngredients: NetworkIngredient) -> Observable<[Ingredient]>
-    func request(detailIngredient: NetworkIngredient) -> Observable<[Ingredient]>
-    func request(saveIngredient: NetworkImage) -> Observable<CommonResponse>
-    func request(modifyIngredient: NetworkImage) -> Observable<CommonResponse>
-    func request(deleteIngredient: NetworkIngredient) -> Observable<CommonResponse>
+    func request(closerIngredients: NetworkIngredient)
+    -> Observable<(commonResponse: CommonResponse, ingredients: [Ingredient])>
+    
+    func request(endIngredients: NetworkIngredient)
+    -> Observable<(commonResponse: CommonResponse, ingredients: [Ingredient])>
+    
+    func request(searchIngredients: NetworkIngredient)
+    -> Observable<(commonResponse: CommonResponse, ingredients: [Ingredient])>
+    
+    func request(detailIngredient: NetworkIngredient)
+    -> Observable<(commonResponse: CommonResponse, ingredients: [Ingredient])>
+    
+    func request(saveIngredient: NetworkImage)
+    -> Observable<CommonResponse>
+    
+    func request(modifyIngredient: NetworkImage)
+    -> Observable<CommonResponse>
+    
+    func request(deleteIngredient: NetworkIngredient)
+    -> Observable<CommonResponse>
 }
 
 struct IngredientRepository: IngredientRepositoryProtocol {
-    func request(closerIngredients: NetworkIngredient) -> Observable<[Ingredient]> {
+    func request(closerIngredients: NetworkIngredient)
+    -> Observable<(commonResponse: CommonResponse, ingredients: [Ingredient])> {
         let observable: Observable<IngredientResponseDTO> = Network.requestJSON(target: closerIngredients)
         return observable.map { $0.toDomain() }
     }
     
-    func request(endIngredients: NetworkIngredient) -> Observable<[Ingredient]> {
+    func request(endIngredients: NetworkIngredient)
+    -> Observable<(commonResponse: CommonResponse, ingredients: [Ingredient])> {
         let observable: Observable<IngredientResponseDTO> = Network.requestJSON(target: endIngredients)
         return observable.map { $0.toDomain() }
     }
     
-    func request(searchIngredients: NetworkIngredient) -> Observable<[Ingredient]> {
+    func request(searchIngredients: NetworkIngredient)
+    -> Observable<(commonResponse: CommonResponse, ingredients: [Ingredient])> {
         let observable: Observable<IngredientResponseDTO> = Network.requestJSON(target: searchIngredients)
         return observable.map { $0.toDomain() }
     }
     
-    func request(detailIngredient: NetworkIngredient) -> Observable<[Ingredient]> {
+    func request(detailIngredient: NetworkIngredient)
+    -> Observable<(commonResponse: CommonResponse, ingredients: [Ingredient])> {
         let observable: Observable<IngredientResponseDTO> = Network.requestJSON(target: detailIngredient)
         return observable.map { $0.toDomain() }
     }

--- a/ReFree/Source/Data/Repository/RecipeRepository.swift
+++ b/ReFree/Source/Data/Repository/RecipeRepository.swift
@@ -9,20 +9,25 @@ import Foundation
 import RxSwift
 
 protocol RecipeRepositoryProtocol {
-    func request(recommendRecipe: NetworkRecipe) -> Observable<[Recipe]>
-    func request(searchRecipe: NetworkRecipe) -> Observable<[Recipe]>
+    func request(recommendRecipe: NetworkRecipe)
+    -> Observable<(commonResponse: CommonResponse, recipes: [Recipe])>
+    func request(searchRecipe: NetworkRecipe)
+    -> Observable<(commonResponse: CommonResponse, recipes: [Recipe])>
     func request(bookMark: NetworkRecipe) -> Observable<CommonResponse>
     func request(detailRecipe: NetworkRecipe) -> Observable<[Manual]>
-    func request(savedRecipe: NetworkRecipe) -> Observable<[Recipe]>
+    func request(savedRecipe: NetworkRecipe)
+    -> Observable<(commonResponse: CommonResponse, recipes: [Recipe])>
 }
 
 struct RecipeRepository: RecipeRepositoryProtocol {
-    func request(recommendRecipe: NetworkRecipe) -> Observable<[Recipe]> {
+    func request(recommendRecipe: NetworkRecipe)
+    -> Observable<(commonResponse: CommonResponse, recipes: [Recipe])> {
         let observable: Observable<RecipeResponseDTO> = Network.requestJSON(target: recommendRecipe)
         return observable.map { $0.toDomain() }
     }
     
-    func request(searchRecipe: NetworkRecipe) -> Observable<[Recipe]> {
+    func request(searchRecipe: NetworkRecipe)
+    -> Observable<(commonResponse: CommonResponse, recipes: [Recipe])> {
         let observable: Observable<RecipeResponseDTO> = Network.requestJSON(target: searchRecipe)
         return observable.map { $0.toDomain() }
     }
@@ -37,7 +42,8 @@ struct RecipeRepository: RecipeRepositoryProtocol {
         return observable.map { $0.toDomainManual() }
     }
     
-    func request(savedRecipe: NetworkRecipe) -> Observable<[Recipe]> {
+    func request(savedRecipe: NetworkRecipe)
+    -> Observable<(commonResponse: CommonResponse, recipes: [Recipe])> {
         let observable: Observable<RecipeResponseDTO> = Network.requestJSON(target: savedRecipe)
         return observable.map { $0.toDomain() }
     }

--- a/ReFree/Source/Data/Repository/RecipeRepository.swift
+++ b/ReFree/Source/Data/Repository/RecipeRepository.swift
@@ -11,10 +11,16 @@ import RxSwift
 protocol RecipeRepositoryProtocol {
     func request(recommendRecipe: NetworkRecipe)
     -> Observable<(commonResponse: CommonResponse, recipes: [Recipe])>
+    
     func request(searchRecipe: NetworkRecipe)
     -> Observable<(commonResponse: CommonResponse, recipes: [Recipe])>
-    func request(bookMark: NetworkRecipe) -> Observable<CommonResponse>
-    func request(detailRecipe: NetworkRecipe) -> Observable<[Manual]>
+    
+    func request(bookMark: NetworkRecipe)
+    -> Observable<CommonResponse>
+    
+    func request(detailRecipe: NetworkRecipe)
+    -> Observable<(commonResponse: CommonResponse, manuals: [Manual])>
+    
     func request(savedRecipe: NetworkRecipe)
     -> Observable<(commonResponse: CommonResponse, recipes: [Recipe])>
 }
@@ -37,7 +43,8 @@ struct RecipeRepository: RecipeRepositoryProtocol {
         return observable.map { $0.toDomain() }
     }
     
-    func request(detailRecipe: NetworkRecipe) -> Observable<[Manual]> {
+    func request(detailRecipe: NetworkRecipe)
+    -> Observable<(commonResponse: CommonResponse, manuals: [Manual])> {
         let observable: Observable<RecipeResponseDTO> = Network.requestJSON(target: detailRecipe)
         return observable.map { $0.toDomainManual() }
     }

--- a/ReFree/Source/Data/Repository/SignRepository.swift
+++ b/ReFree/Source/Data/Repository/SignRepository.swift
@@ -10,11 +10,20 @@ import RxSwift
 
 
 protocol SignRepositoryProtocol {
-    func request(signIn: NetworkSign) -> Observable<(response: CommonResponse, token: String)>
-    func request(signUp: NetworkSign) -> Observable<(response: CommonResponse, backupCode: String)>
-    func request(findPassword: NetworkSign) -> Observable<CommonResponse>
-    func request(modifyPassword: NetworkSign) -> Observable<CommonResponse>
-    func request(withdrawUser: NetworkSign) -> Observable<CommonResponse>
+    func request(signIn: NetworkSign)
+    -> Observable<(response: CommonResponse, token: String)>
+    
+    func request(signUp: NetworkSign)
+    -> Observable<(response: CommonResponse, backupCode: String)>
+    
+    func request(findPassword: NetworkSign)
+    -> Observable<CommonResponse>
+    
+    func request(modifyPassword: NetworkSign)
+    -> Observable<CommonResponse>
+    
+    func request(withdrawUser: NetworkSign)
+    -> Observable<CommonResponse>
 }
 
 struct SignRepository: SignRepositoryProtocol {

--- a/ReFree/Source/Home/ViewController/HomeViewController.swift
+++ b/ReFree/Source/Home/ViewController/HomeViewController.swift
@@ -112,7 +112,7 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITextFieldDele
         foodButtonSelected()
         
         ingredientRepository.request(closerIngredients: .closerIngredients)
-            .subscribe(onNext: { [weak self] ingredients in
+            .subscribe(onNext: { [weak self] (commonResponse, ingredients) in
                 guard let self else { return }
                 self.ingredients = ingredients
                 self.foodTableView.reloadData()
@@ -129,7 +129,7 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITextFieldDele
         foodButtonSelected()
         
         ingredientRepository.request(endIngredients: .endIngredients)
-            .subscribe(onNext: { [weak self] ingredients in
+            .subscribe(onNext: { [weak self] (commonResponse, ingredients) in
                 guard let self else { return }
                 self.ingredients = ingredients
                 self.foodTableView.reloadData()

--- a/ReFree/Source/Home/ViewController/HomeViewController.swift
+++ b/ReFree/Source/Home/ViewController/HomeViewController.swift
@@ -113,6 +113,7 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITextFieldDele
         
         ingredientRepository.request(closerIngredients: .closerIngredients)
             .subscribe(onNext: { [weak self] (commonResponse, ingredients) in
+                self?.responseCheck(response: commonResponse)
                 guard let self else { return }
                 self.ingredients = ingredients
                 self.foodTableView.reloadData()
@@ -130,6 +131,7 @@ class HomeViewController: UIViewController, UITableViewDelegate, UITextFieldDele
         
         ingredientRepository.request(endIngredients: .endIngredients)
             .subscribe(onNext: { [weak self] (commonResponse, ingredients) in
+                self?.responseCheck(response: commonResponse)
                 guard let self else { return }
                 self.ingredients = ingredients
                 self.foodTableView.reloadData()

--- a/ReFree/Source/KindRecipe/ViewController/KindRecipeViewController.swift
+++ b/ReFree/Source/KindRecipe/ViewController/KindRecipeViewController.swift
@@ -173,6 +173,7 @@ final class KindRecipeViewController: UIViewController {
         if kind == TitleKind.saved {
             recipeRepository.request(savedRecipe: .savedRecipe)
                 .subscribe(onNext: { [weak self] (commonResponse, recipes) in
+                    self?.responseCheck(response: commonResponse)
                     guard let self else { return }
                     self.recipes += recipes
                     self.collectionView.reloadData()
@@ -192,6 +193,7 @@ final class KindRecipeViewController: UIViewController {
                     )
                 )
                 .subscribe(onNext: { [weak self] (commonResponse, recipes) in
+                    self?.responseCheck(response: commonResponse)
                     guard let self else { return }
                     self.recipes += recipes
                     self.collectionView.reloadData()
@@ -206,6 +208,7 @@ final class KindRecipeViewController: UIViewController {
                     )
                 )
                 .subscribe(onNext: { [weak self] (commonResponse, recipes) in
+                    self?.responseCheck(response: commonResponse)
                     guard let self else { return }
                     self.recipes += recipes
                     self.collectionView.reloadData()

--- a/ReFree/Source/KindRecipe/ViewController/KindRecipeViewController.swift
+++ b/ReFree/Source/KindRecipe/ViewController/KindRecipeViewController.swift
@@ -172,7 +172,7 @@ final class KindRecipeViewController: UIViewController {
         let isSearch = !(searchBar.textField.text ?? "").isEmpty
         if kind == TitleKind.saved {
             recipeRepository.request(savedRecipe: .savedRecipe)
-                .subscribe(onNext: { [weak self] recipes in
+                .subscribe(onNext: { [weak self] (commonResponse, recipes) in
                     guard let self else { return }
                     self.recipes += recipes
                     self.collectionView.reloadData()
@@ -191,7 +191,7 @@ final class KindRecipeViewController: UIViewController {
                         ]
                     )
                 )
-                .subscribe(onNext: { [weak self] recipes in
+                .subscribe(onNext: { [weak self] (commonResponse, recipes) in
                     guard let self else { return }
                     self.recipes += recipes
                     self.collectionView.reloadData()
@@ -205,7 +205,7 @@ final class KindRecipeViewController: UIViewController {
                         query: [.init("type", kind.searchQueryValue), .init("offset", page)]
                     )
                 )
-                .subscribe(onNext: { [weak self] recipes in
+                .subscribe(onNext: { [weak self] (commonResponse, recipes) in
                     guard let self else { return }
                     self.recipes += recipes
                     self.collectionView.reloadData()

--- a/ReFree/Source/Recipe/ViewController/RecipeViewController.swift
+++ b/ReFree/Source/Recipe/ViewController/RecipeViewController.swift
@@ -241,7 +241,8 @@ final class RecipeViewController: UIViewController {
                 ingredients: ["토마토", "연어", "오이"]
             )
         )
-        .subscribe(onNext: { [weak self] recipes in
+        .subscribe(onNext: { [weak self] (commonResponse, recipes) in
+            
             self?.recipes = recipes
             self?.carouselCollectionView.reloadData()
             self?.loadingCompletion()
@@ -252,7 +253,7 @@ final class RecipeViewController: UIViewController {
                 message: "\(error.localizedDescription)"
             )
         })
-        .disposed(by: disposeBag)
+        .disposed(by: disposeBag)  
     }
     
     private func openSidebar() {

--- a/ReFree/Source/Recipe/ViewController/RecipeViewController.swift
+++ b/ReFree/Source/Recipe/ViewController/RecipeViewController.swift
@@ -242,7 +242,7 @@ final class RecipeViewController: UIViewController {
             )
         )
         .subscribe(onNext: { [weak self] (commonResponse, recipes) in
-            
+            self?.responseCheck(response: commonResponse)
             self?.recipes = recipes
             self?.carouselCollectionView.reloadData()
             self?.loadingCompletion()

--- a/ReFree/Source/Refrigerator/ViewController/RefrigeratorViewController.swift
+++ b/ReFree/Source/Refrigerator/ViewController/RefrigeratorViewController.swift
@@ -260,7 +260,7 @@ class RefrigeratorViewController: UIViewController {
     private func bindDefaultData() {
         changeSelectedButtonLayout(saveKind: .whole)
         ingredientRepo.request(searchIngredients: .searchIngredients())
-            .subscribe(onNext: { [weak self] ingredients in
+            .subscribe(onNext: { [weak self] (commonResponse, ingredients) in
                 self?.ingredients = ingredients
                 self?.collectionView.reloadData()
             }, onError: { error in
@@ -283,7 +283,7 @@ class RefrigeratorViewController: UIViewController {
                             searchKey: searchKey
                         )
                     )
-                    .subscribe(onNext: { [weak self] ingredients in
+                    .subscribe(onNext: { [weak self] (commonResponse, ingredients) in
                         self?.ingredients = ingredients
                         self?.collectionView.reloadData()
                     }, onError: { error in
@@ -329,7 +329,7 @@ class RefrigeratorViewController: UIViewController {
         changeSelectedButtonLayout(saveKind: .whole)
         currentKind = .whole
         ingredientRepo.request(searchIngredients: .searchIngredients())
-            .subscribe(onNext: { [weak self] ingredients in
+            .subscribe(onNext: { [weak self] (commonResponse, ingredients) in
                 self?.ingredients = ingredients
                 self?.collectionView.reloadData()
             }, onError: { error in
@@ -342,7 +342,7 @@ class RefrigeratorViewController: UIViewController {
         changeSelectedButtonLayout(saveKind: .refrigerd)
         currentKind = .refrigerd
         ingredientRepo.request(searchIngredients: .searchIngredients(options: .refrigerd))
-            .subscribe(onNext: { [weak self] ingredients in
+            .subscribe(onNext: { [weak self] (commonResponse, ingredients) in
                 self?.ingredients = ingredients
                 self?.collectionView.reloadData()
             }, onError: { error in
@@ -355,7 +355,7 @@ class RefrigeratorViewController: UIViewController {
         changeSelectedButtonLayout(saveKind: .frozen)
         currentKind = .frozen
         ingredientRepo.request(searchIngredients: .searchIngredients(options: .frozen))
-            .subscribe(onNext: { [weak self] ingredients in
+            .subscribe(onNext: { [weak self] (commonResponse, ingredients) in
                 self?.ingredients = ingredients
                 self?.collectionView.reloadData()
             }, onError: { error in
@@ -368,7 +368,7 @@ class RefrigeratorViewController: UIViewController {
         changeSelectedButtonLayout(saveKind: .outdoor)
         currentKind = .outdoor
         ingredientRepo.request(searchIngredients: .searchIngredients(options: .outdoor))
-            .subscribe(onNext: { [weak self] ingredients in
+            .subscribe(onNext: { [weak self] (commonResponse, ingredients) in
                 self?.ingredients = ingredients
                 self?.collectionView.reloadData()
             }, onError: { error in

--- a/ReFree/Source/Refrigerator/ViewController/RefrigeratorViewController.swift
+++ b/ReFree/Source/Refrigerator/ViewController/RefrigeratorViewController.swift
@@ -261,6 +261,7 @@ class RefrigeratorViewController: UIViewController {
         changeSelectedButtonLayout(saveKind: .whole)
         ingredientRepo.request(searchIngredients: .searchIngredients())
             .subscribe(onNext: { [weak self] (commonResponse, ingredients) in
+                self?.responseCheck(response: commonResponse)
                 self?.ingredients = ingredients
                 self?.collectionView.reloadData()
             }, onError: { error in
@@ -284,6 +285,7 @@ class RefrigeratorViewController: UIViewController {
                         )
                     )
                     .subscribe(onNext: { [weak self] (commonResponse, ingredients) in
+                        self?.responseCheck(response: commonResponse)
                         self?.ingredients = ingredients
                         self?.collectionView.reloadData()
                     }, onError: { error in
@@ -330,6 +332,7 @@ class RefrigeratorViewController: UIViewController {
         currentKind = .whole
         ingredientRepo.request(searchIngredients: .searchIngredients())
             .subscribe(onNext: { [weak self] (commonResponse, ingredients) in
+                self?.responseCheck(response: commonResponse)
                 self?.ingredients = ingredients
                 self?.collectionView.reloadData()
             }, onError: { error in
@@ -343,6 +346,7 @@ class RefrigeratorViewController: UIViewController {
         currentKind = .refrigerd
         ingredientRepo.request(searchIngredients: .searchIngredients(options: .refrigerd))
             .subscribe(onNext: { [weak self] (commonResponse, ingredients) in
+                self?.responseCheck(response: commonResponse)
                 self?.ingredients = ingredients
                 self?.collectionView.reloadData()
             }, onError: { error in
@@ -356,6 +360,7 @@ class RefrigeratorViewController: UIViewController {
         currentKind = .frozen
         ingredientRepo.request(searchIngredients: .searchIngredients(options: .frozen))
             .subscribe(onNext: { [weak self] (commonResponse, ingredients) in
+                self?.responseCheck(response: commonResponse)
                 self?.ingredients = ingredients
                 self?.collectionView.reloadData()
             }, onError: { error in
@@ -369,6 +374,7 @@ class RefrigeratorViewController: UIViewController {
         currentKind = .outdoor
         ingredientRepo.request(searchIngredients: .searchIngredients(options: .outdoor))
             .subscribe(onNext: { [weak self] (commonResponse, ingredients) in
+                self?.responseCheck(response: commonResponse)
                 self?.ingredients = ingredients
                 self?.collectionView.reloadData()
             }, onError: { error in

--- a/ReFree/Source/Util/Extension/UIViewController+ResponseCheck.swift
+++ b/ReFree/Source/Util/Extension/UIViewController+ResponseCheck.swift
@@ -1,14 +1,13 @@
 //
-//  UIView+ResponseCheck.swift
+//  UIViewController+ResponseCheck.swift
 //  ReFree
 //
-//  Created by 이주훈 on 2023/08/11.
+//  Created by 이주훈 on 2023/08/12.
 //
 
 import UIKit
 
-// UIView의 로직을 UIVIewController로 리팩토링 시 삭제 예정
-extension UIView {
+extension UIViewController {
     func responseCheck(response: CommonResponse) {
         switch response.code {
         case "200": break
@@ -19,8 +18,9 @@ extension UIView {
     
     private func loginExpired() {
         guard
-            let sceneDelegate = self.window?.windowScene?.delegate as? SceneDelegate
+            let sceneDelegate = view.window?.windowScene?.delegate as? SceneDelegate
         else { return }
         sceneDelegate.popToRootViewController()
     }
 }
+


### PR DESCRIPTION
## 설명
[RF-283]
- respository들의 각 request가 CommonResponse를 Tuple로 리턴하도록 변경했습니다.
  -  서버에서 response code가 아닌 실패시에도 CommonResPonse를 내려줌으로써 에러를 구분하기 때문
- 에러 코드를 식별하는 extension responseCheck를 만들었습니다. 현재는 401(로그인 토큰 만료) 코드만 필터링하고 있습니다.
- 각 API를 호출하는 부분에서 모두 commonResponse를 확인하도록 했습니다.

## 이슈
[RF-284]
[RF-301]
[RF-302]


[RF-283]: https://juhun-lee.atlassian.net/browse/RF-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RF-284]: https://juhun-lee.atlassian.net/browse/RF-284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RF-301]: https://juhun-lee.atlassian.net/browse/RF-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RF-302]: https://juhun-lee.atlassian.net/browse/RF-302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ